### PR TITLE
`initializeIcons()` in various quickstarts

### DIFF
--- a/ui-library-quickstart-composites/package-lock.json
+++ b/ui-library-quickstart-composites/package-lock.json
@@ -20,11 +20,11 @@
       }
     },
     "@azure/communication-calling": {
-      "version": "1.6.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@azure/communication-calling/-/communication-calling-1.6.1-beta.1.tgz",
-      "integrity": "sha512-VWMcKU1taJ8E9n3bsY8XlatKoTSkKCMYPRGusEC2UfjS/eGlRPRZ7sk1fZEESvCny6Y4Q7dKZv4OqbW5e6VfeQ==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@azure/communication-calling/-/communication-calling-1.4.4.tgz",
+      "integrity": "sha512-uWzULqnXB7pMIEH8x1mwwT45ncPfAryfoKxd4BtbcL1C3ckMknk/5gP3Ov2/V5DJkoOO3I6A4D1n05eSFRy+zA==",
       "requires": {
-        "@azure/communication-common": "^2.0.0",
+        "@azure/communication-common": "^1.0.0",
         "@azure/logger": "^1.0.2"
       }
     },
@@ -75,49 +75,39 @@
       }
     },
     "@azure/communication-common": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@azure/communication-common/-/communication-common-2.2.0.tgz",
-      "integrity": "sha512-92zGSs+qwWHEqCRIGAudYhPgnUT270Y3Mb2xuYH253IF3da74A+GyNhSEma0Zy6qHb+c5oHkh4Ijr2ndhrBQ2A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/communication-common/-/communication-common-1.1.0.tgz",
+      "integrity": "sha512-vqTtzDtb4NG3LWoWoqlOOJApZRRIIImNUKlGyTa6c1YC+v5A7UEOL9TX8NRDxvFVUF2wDHsSnkhLBVBgkcAhIQ==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-auth": "^1.3.0",
-        "@azure/core-rest-pipeline": "^1.3.2",
-        "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.0.0",
+        "@azure/core-http": "^2.0.0",
+        "@azure/core-tracing": "1.0.0-preview.13",
         "events": "^3.0.0",
-        "jwt-decode": "^3.1.2",
+        "jwt-decode": "~2.2.0",
         "tslib": "^2.2.0"
       },
       "dependencies": {
-        "@azure/core-tracing": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
-          "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
-          "requires": {
-            "tslib": "^2.2.0"
-          }
-        },
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@azure/communication-react": {
-      "version": "1.3.2-beta.1",
-      "resolved": "https://registry.npmjs.org/@azure/communication-react/-/communication-react-1.3.2-beta.1.tgz",
-      "integrity": "sha512-zTEQWhydXiccDcykCJ+sXDhqmCASDTFCAfxkEz7PeoAtc8bSGAbDDn++q5AMcG5aYL8Am6HhkyZxlaZY9PLA7A==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/communication-react/-/communication-react-1.3.1.tgz",
+      "integrity": "sha512-TybRu2xLQdzdRN3EyyEwArSg0Akw3So5W/RjoL3ifMLj5TPzeSXvf8KQtF7pBW+pHxrfoDvu3fMiCxx2sUw5fQ==",
       "requires": {
         "@azure/communication-common": "2.0.0",
-        "@azure/core-client": "1.3.0",
+        "@azure/core-http": "1.2.4",
         "@azure/core-paging": "~1.1.3",
-        "@azure/core-rest-pipeline": "~1.9.2",
         "@azure/logger": "1.0.3",
-        "@fluentui/react": "~8.62.4",
+        "@fluentui/react": "~8.17.2",
         "@fluentui/react-file-type-icons": "~8.5.8",
         "@fluentui/react-hooks": "~8.3.8",
-        "@fluentui/react-icons": "~1.1.145",
+        "@fluentui/react-icons": "~1.1.137",
         "@fluentui/react-northstar": "0.61.0",
         "@fluentui/react-window-provider": "~2.2.0",
         "copy-to-clipboard": "~3.3.1",
@@ -146,17 +136,38 @@
             "tslib": "^2.2.0"
           }
         },
-        "@azure/core-client": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.3.0.tgz",
-          "integrity": "sha512-4ricu3aM1TQP2vglBcvFX8KgbWVe+7hl1jVAw6BzIGG4CTAvO3ygDS6th3O+zFwGN9xkgXFHa7Tp3u9za8ciIA==",
+        "@azure/core-http": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.2.4.tgz",
+          "integrity": "sha512-cNumz3ckyFZY5zWOgcTHSO7AKRVwxbodG8WfcEGcdH+ZJL3KvJEI/vN58H6xk5v3ijulU2x/WPGJqrMVvcI79A==",
           "requires": {
             "@azure/abort-controller": "^1.0.0",
             "@azure/core-asynciterator-polyfill": "^1.0.0",
             "@azure/core-auth": "^1.3.0",
-            "@azure/core-rest-pipeline": "^1.1.0",
-            "@azure/core-tracing": "1.0.0-preview.13",
-            "tslib": "^2.2.0"
+            "@azure/core-tracing": "1.0.0-preview.11",
+            "@azure/logger": "^1.0.0",
+            "@types/node-fetch": "^2.5.0",
+            "@types/tunnel": "^0.0.1",
+            "form-data": "^3.0.0",
+            "node-fetch": "^2.6.0",
+            "process": "^0.11.10",
+            "tough-cookie": "^4.0.0",
+            "tslib": "^2.0.0",
+            "tunnel": "^0.0.6",
+            "uuid": "^8.3.0",
+            "xml2js": "^0.4.19"
+          },
+          "dependencies": {
+            "@azure/core-tracing": {
+              "version": "1.0.0-preview.11",
+              "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.11.tgz",
+              "integrity": "sha512-frF0pJc9HTmKncVokhBxCqipjbql02DThQ1ZJ9wLi7SDMLdPAFyDI5xZNzX5guLz+/DtPkY+SGK2li9FIXqshQ==",
+              "requires": {
+                "@opencensus/web-types": "0.0.7",
+                "@opentelemetry/api": "1.0.0-rc.0",
+                "tslib": "^2.0.0"
+              }
+            }
           }
         },
         "@azure/core-paging": {
@@ -167,37 +178,17 @@
             "@azure/core-asynciterator-polyfill": "^1.0.0"
           }
         },
-        "@fluentui/react": {
-          "version": "8.62.4",
-          "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.62.4.tgz",
-          "integrity": "sha512-vwN6fg5n8xxynnW0Cmjk4Qao+6OE/bOF8k1hoMdufkKTJx1VpRa1SZHMgHCh0/kXoXWQyBeyetcUOPjXw/sPlQ==",
+        "@opentelemetry/api": {
+          "version": "1.0.0-rc.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.0-rc.0.tgz",
+          "integrity": "sha512-iXKByCMfrlO5S6Oh97BuM56tM2cIBB0XsL/vWF/AtJrJEKx4MC/Xdu0xDsGXMGcNWpqF7ujMsjjnp0+UHBwnDQ=="
+        },
+        "@types/tunnel": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
+          "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
           "requires": {
-            "@fluentui/date-time-utilities": "^8.5.0",
-            "@fluentui/font-icons-mdl2": "^8.2.5",
-            "@fluentui/foundation-legacy": "^8.2.5",
-            "@fluentui/merge-styles": "^8.5.0",
-            "@fluentui/react-focus": "^8.5.6",
-            "@fluentui/react-hooks": "^8.5.3",
-            "@fluentui/react-window-provider": "^2.2.0",
-            "@fluentui/set-version": "^8.2.0",
-            "@fluentui/style-utilities": "^8.6.5",
-            "@fluentui/theme": "^2.6.4",
-            "@fluentui/utilities": "^8.8.1",
-            "@microsoft/load-themed-styles": "^1.10.26",
-            "tslib": "^2.1.0"
-          },
-          "dependencies": {
-            "@fluentui/react-hooks": {
-              "version": "8.6.13",
-              "resolved": "https://registry.npmjs.org/@fluentui/react-hooks/-/react-hooks-8.6.13.tgz",
-              "integrity": "sha512-RAbVuwzX40czyNNkVpRFYKST2dX+PL0qIT5LB92SWqhEfyZjMOcOeg/YaEoLFZKNOVilAfUItSCD6HzurO4aLA==",
-              "requires": {
-                "@fluentui/react-window-provider": "^2.2.4",
-                "@fluentui/set-version": "^8.2.3",
-                "@fluentui/utilities": "^8.13.3",
-                "tslib": "^2.1.0"
-              }
-            }
+            "@types/node": "*"
           }
         },
         "immer": {
@@ -205,15 +196,20 @@
           "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
           "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ=="
         },
+        "jwt-decode": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+          "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+        },
         "nanoid": {
           "version": "3.1.32",
           "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.32.tgz",
           "integrity": "sha512-F8mf7R3iT9bvThBoW4tGXhXFHCctyCiUUPrWF8WaTqa3h96d9QybkSeba43XVOOE3oiLfkVDe4bT8MeGmkrTxw=="
         },
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -1677,141 +1673,129 @@
       }
     },
     "@fluentui/date-time-utilities": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.5.3.tgz",
-      "integrity": "sha512-jwbwcJlnerdjENIAfn/YHxl5H2sQruReOMWXWMgmvX0CmcbqsN9VBxBt+E35Tlr4Ds3MbGs60eyfZUIPpaB5RQ==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.5.2.tgz",
+      "integrity": "sha512-u540ACUdnC+Jms1DIHkho80eJmoCg/LtAzR4a/1Tum6PicxWv59UYp9Ba7qFbIw+mrjWnwX/2ZmBpqTy9Rgn7w==",
       "requires": {
-        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/set-version": "^8.2.2",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@fluentui/dom-utilities": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.3.tgz",
-      "integrity": "sha512-Ml/xwpTC6vb9lHHVAbSUD9jMbt9nVzV208D0FEoQn0c0+dP2vdMXSvXC/QHs/57B6JicttVQPuX6EcPwR3Mkpg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.2.tgz",
+      "integrity": "sha512-puklLc6Jvg279OGagqkSfuHML6ckBhw3gJakdvIZHKeJiduh+34U4Finl3K24yBSXzG2WsN+LwLTd1Vcociy+g==",
       "requires": {
-        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/set-version": "^8.2.2",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@fluentui/font-icons-mdl2": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.5.3.tgz",
-      "integrity": "sha512-C1P2fvaj8kka4tLJOoZPopq4kz2ZNCZ4ImGVvek8t7DOayOU2UoTKNoVKhNjynagbsLpwpOYA8Uzb4Ialx+/uQ==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.5.2.tgz",
+      "integrity": "sha512-qDbZNiXVPx6X/Z2MpU3Oa2kWNSrk5+mG8ZRdH/thD7iwnV4l6DtBctNyXK/Cjq4EpG3eQQra8LBVxwOyDt0GqA==",
       "requires": {
-        "@fluentui/set-version": "^8.2.3",
-        "@fluentui/style-utilities": "^8.8.2",
-        "@fluentui/utilities": "^8.13.3",
+        "@fluentui/set-version": "^8.2.2",
+        "@fluentui/style-utilities": "^8.8.1",
+        "@fluentui/utilities": "^8.13.2",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@fluentui/foundation-legacy": {
-      "version": "8.2.23",
-      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.2.23.tgz",
-      "integrity": "sha512-5idaKH7z0HKRAlfGH4BjqSlRKQh4yzVd5BWJ0MCPL20Rn6jmaIJSdjMHTrIfVhzLvSxn+7MQRV9a8S+AvIDUHQ==",
+      "version": "8.2.22",
+      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.2.22.tgz",
+      "integrity": "sha512-wyv5KxmgG/Qivd0eUkQ4mpAdy3caPV9WrPd10MMw/0TGyCCrzq7+REZYVilRy1+VWQspQxWxRH7Kex9+LqPlKA==",
       "requires": {
-        "@fluentui/merge-styles": "^8.5.4",
-        "@fluentui/set-version": "^8.2.3",
-        "@fluentui/style-utilities": "^8.8.2",
-        "@fluentui/utilities": "^8.13.3",
+        "@fluentui/merge-styles": "^8.5.3",
+        "@fluentui/set-version": "^8.2.2",
+        "@fluentui/style-utilities": "^8.8.1",
+        "@fluentui/utilities": "^8.13.2",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@fluentui/keyboard-key": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.4.3.tgz",
-      "integrity": "sha512-uLiwx+UyXDN7tShv/s2NzDPtqeT/BZCHvY9yxEeb6LgEkos8TZvT5ep/7G8BpxA/SuBnviZ8xpDB5JObyZikqQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.4.2.tgz",
+      "integrity": "sha512-6WdMrnFpY94uWefUGGRqO4WiS6R+Kso6/FR95SxXMuS6kfnjGJCHzywFGZcN5OU1fX067Zna4aPQ/nDwYMgBPw==",
       "requires": {
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@fluentui/merge-styles": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.4.tgz",
-      "integrity": "sha512-CeQIEcEgZu0cxqqyhJyTqySXoUL1vXfdWDJ8WMzchaNnhvOvoXISw8xXHpNXUtEn+HgPrcy9mHQwFcAc+jv3Wg==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.3.tgz",
+      "integrity": "sha512-bHWftN3zTp1bbBfmAEH8YK9UURWj2mffw7b7VaW2Og1qxwv3GMSza1cyv/d3EVqpMJ8AVwFv3mbi9p1ieMN9mw==",
       "requires": {
-        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/set-version": "^8.2.2",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@fluentui/react": {
-      "version": "8.101.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.101.0.tgz",
-      "integrity": "sha512-kIVujMFy/vszhCO4GwxMhEIcQ9NCWm2GOqXjX0X/iLzR6g0yOUwzIfdTcKJrD8zpg1g41pANeYdpAnWrl/se6g==",
+      "version": "8.17.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.17.4.tgz",
+      "integrity": "sha512-9H9kNL8p/hpVIXk0SPh7ExhX00HuBofbbeU6rnBqWbKfOdbV+iQ8INsvZWAE1JcWoaxP3iscZcM3N0ViH218HA==",
       "requires": {
-        "@fluentui/date-time-utilities": "^8.5.3",
-        "@fluentui/font-icons-mdl2": "^8.5.3",
-        "@fluentui/foundation-legacy": "^8.2.23",
-        "@fluentui/merge-styles": "^8.5.4",
-        "@fluentui/react-focus": "^8.8.9",
-        "@fluentui/react-hooks": "^8.6.13",
-        "@fluentui/react-portal-compat-context": "^9.0.3",
-        "@fluentui/react-window-provider": "^2.2.4",
-        "@fluentui/set-version": "^8.2.3",
-        "@fluentui/style-utilities": "^8.8.2",
-        "@fluentui/theme": "^2.6.18",
-        "@fluentui/utilities": "^8.13.3",
+        "@fluentui/date-time-utilities": "^8.1.2",
+        "@fluentui/font-icons-mdl2": "^8.1.2",
+        "@fluentui/foundation-legacy": "^8.1.2",
+        "@fluentui/merge-styles": "^8.1.2",
+        "@fluentui/react-focus": "^8.1.3",
+        "@fluentui/react-hooks": "^8.2.2",
+        "@fluentui/react-window-provider": "^2.1.2",
+        "@fluentui/set-version": "^8.1.2",
+        "@fluentui/style-utilities": "^8.1.2",
+        "@fluentui/theme": "^2.1.2",
+        "@fluentui/utilities": "^8.1.2",
         "@microsoft/load-themed-styles": "^1.10.26",
         "tslib": "^2.1.0"
       },
       "dependencies": {
-        "@fluentui/react-hooks": {
-          "version": "8.6.13",
-          "resolved": "https://registry.npmjs.org/@fluentui/react-hooks/-/react-hooks-8.6.13.tgz",
-          "integrity": "sha512-RAbVuwzX40czyNNkVpRFYKST2dX+PL0qIT5LB92SWqhEfyZjMOcOeg/YaEoLFZKNOVilAfUItSCD6HzurO4aLA==",
-          "requires": {
-            "@fluentui/react-window-provider": "^2.2.4",
-            "@fluentui/set-version": "^8.2.3",
-            "@fluentui/utilities": "^8.13.3",
-            "tslib": "^2.1.0"
-          }
-        },
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -1872,29 +1856,29 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@fluentui/react-focus": {
-      "version": "8.8.9",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.8.9.tgz",
-      "integrity": "sha512-lYixFOZ2OjULcWhD3MppxzAt6aImkhNQiNtUJzswBV1xmYvkpYOxXK2hxf3/CeRAFijcmuAIvwg1rRgYBfRxxA==",
+      "version": "8.8.8",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.8.8.tgz",
+      "integrity": "sha512-N4JmmduWk50tIGTH6kYTDa1HJfJ9qzGztbmo7HEh+gzHLwHDkL0GOV5+VWfwPuBcUqD1eKP4fz/e/gCBswBShg==",
       "requires": {
-        "@fluentui/keyboard-key": "^0.4.3",
-        "@fluentui/merge-styles": "^8.5.4",
-        "@fluentui/set-version": "^8.2.3",
-        "@fluentui/style-utilities": "^8.8.2",
-        "@fluentui/utilities": "^8.13.3",
+        "@fluentui/keyboard-key": "^0.4.2",
+        "@fluentui/merge-styles": "^8.5.3",
+        "@fluentui/set-version": "^8.2.2",
+        "@fluentui/style-utilities": "^8.8.1",
+        "@fluentui/utilities": "^8.13.2",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -1910,9 +1894,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -2003,21 +1987,6 @@
         "@fluentui/styles": "^0.61.0"
       }
     },
-    "@fluentui/react-portal-compat-context": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-portal-compat-context/-/react-portal-compat-context-9.0.3.tgz",
-      "integrity": "sha512-XZczqvKJflK6jFv6RekFXzZFnxvd1tBbIsRFs6JMX8zNqMO7ZQJ6Yfee5LLs6HnZE5BKowE7jIUMOTH9yOmyJg==",
-      "requires": {
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
-        }
-      }
-    },
     "@fluentui/react-proptypes": {
       "version": "0.61.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-proptypes/-/react-proptypes-0.61.0.tgz",
@@ -2029,33 +1998,33 @@
       }
     },
     "@fluentui/react-window-provider": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-2.2.4.tgz",
-      "integrity": "sha512-tCiIGQSILSipcn8DwwRgYq5IMtwBKiSQ+/cVRNq54cJZoq5ie/kMGFpldZ+vREDbM8wjmO3eNgNi63A3QRx39g==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-2.2.3.tgz",
+      "integrity": "sha512-uJztbyMu7x/cSYnJ0Rbmult/t22zFnQG20Jtlhmh5/g+M8QiF/T7xz9dkNe4Hon4KmpqnZpd8ds4nmX0fwxODg==",
       "requires": {
-        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/set-version": "^8.2.2",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@fluentui/set-version": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
-      "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.2.tgz",
+      "integrity": "sha512-Vg20KZ0ufgWjxx6GFbqC5wiVxXZDUWgNT0r0By/Eyj4bUSb1jG6lmf5z1oY1dUX0YS6Cp5e6GnvbNdXg5E7orA==",
       "requires": {
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -2068,22 +2037,22 @@
       }
     },
     "@fluentui/style-utilities": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.2.tgz",
-      "integrity": "sha512-tef1nyWmgQTbETmvjQewxLfeJ+sJ21i3VzwBpK5qvj8MLwCHkMSBoDL7gXp6xCN2VSrQc0TkbykgUvRyJ2IReg==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.1.tgz",
+      "integrity": "sha512-asOdSI9+9qgnvpriRuAluREM94iyJJOONA+yZvJiYkVttgFRt77xWrabFjuEbX4pPCmqHhmA0d7dz8zPKgV7cA==",
       "requires": {
-        "@fluentui/merge-styles": "^8.5.4",
-        "@fluentui/set-version": "^8.2.3",
-        "@fluentui/theme": "^2.6.18",
-        "@fluentui/utilities": "^8.13.3",
+        "@fluentui/merge-styles": "^8.5.3",
+        "@fluentui/set-version": "^8.2.2",
+        "@fluentui/theme": "^2.6.17",
+        "@fluentui/utilities": "^8.13.2",
         "@microsoft/load-themed-styles": "^1.10.26",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -2098,38 +2067,38 @@
       }
     },
     "@fluentui/theme": {
-      "version": "2.6.18",
-      "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.18.tgz",
-      "integrity": "sha512-NWiKCX62XDZ8FYjCN0Km4soFfqSyxqoTtxRVBVC5rujbkMbWyzyV/WpGz5ZNcrudhg/5LWNwILhyXxLRalG3mQ==",
+      "version": "2.6.17",
+      "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.17.tgz",
+      "integrity": "sha512-9pxMhOugX3bwY86TresiR6UQNszylD4oiVCAj5s5li7zGos+psdOMrmz9LykIEn1mbAofT/XvRCYfiKECtHEpA==",
       "requires": {
-        "@fluentui/merge-styles": "^8.5.4",
-        "@fluentui/set-version": "^8.2.3",
-        "@fluentui/utilities": "^8.13.3",
+        "@fluentui/merge-styles": "^8.5.3",
+        "@fluentui/set-version": "^8.2.2",
+        "@fluentui/utilities": "^8.13.2",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@fluentui/utilities": {
-      "version": "8.13.3",
-      "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.3.tgz",
-      "integrity": "sha512-Nshe8pWKO/KngRx32EdhW5hvi5ZUWDR6hZcAGNgfLmXXQh3ZrTqAuLtmntv5PHvgbwz1qIsHfvqHgfAcHtoSpw==",
+      "version": "8.13.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.2.tgz",
+      "integrity": "sha512-0AHJBMyYVI7vFChXdPynFf32IYB2y6z4EB5ACzW8UkPFrwkHncbj5pPPE24MCbV7jYR49YrHn9eLY38B+H4iiw==",
       "requires": {
-        "@fluentui/dom-utilities": "^2.2.3",
-        "@fluentui/merge-styles": "^8.5.4",
-        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/dom-utilities": "^2.2.2",
+        "@fluentui/merge-styles": "^8.5.3",
+        "@fluentui/set-version": "^8.2.2",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -2747,6 +2716,11 @@
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
       }
+    },
+    "@opencensus/web-types": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.7.tgz",
+      "integrity": "sha512-xB+w7ZDAu3YBzqH44rCmG9/RlrOmFuDPt/bpf17eJr8eZSrLt7nc7LnWdxM9Mmoj/YKMHpxRg28txu3TcpiL+g=="
     },
     "@opentelemetry/api": {
       "version": "1.2.0",
@@ -3508,9 +3482,9 @@
       }
     },
     "@uifabric/merge-styles": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.20.2.tgz",
-      "integrity": "sha512-cJy8hW9smlWOKgz9xSDMCz/A0yMl4mdo466pcGlIOn84vz+e94grfA7OoTuTzg3Cl0Gj6ODBSf1o0ZwIXYL1Xg==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.20.1.tgz",
+      "integrity": "sha512-LaxbbAGGh/X4x9gwd6kMFIiJKOczy0kHJ1/16b2CAs9De+Ra0mxdTfO9yHbLXKXOvNJcx0mzwaYMDrgBG7cT8A==",
       "requires": {
         "@uifabric/set-version": "^7.0.24",
         "tslib": "^1.10.0"
@@ -3525,12 +3499,12 @@
       }
     },
     "@uifabric/utilities": {
-      "version": "7.38.2",
-      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.38.2.tgz",
-      "integrity": "sha512-5yM4sm142VEBg3/Q5SFheBXqnrZi9CNF5rjHNoex0GgGtG3AHPuS7U8gjm+/Io1MvbuCrn6lyyIw0MDvh1Ebkw==",
+      "version": "7.38.1",
+      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.38.1.tgz",
+      "integrity": "sha512-AdNsDbiARDEtLA9QLGzCYZA7nVKuS7etV7ANvpJ9rko3ApyudRrKZBdHAckd+r8yMCQzg77v8tCfiam2A4jN8g==",
       "requires": {
         "@fluentui/dom-utilities": "^1.1.2",
-        "@uifabric/merge-styles": "^7.20.2",
+        "@uifabric/merge-styles": "^7.20.1",
         "@uifabric/set-version": "^7.0.24",
         "prop-types": "^15.7.2",
         "tslib": "^1.10.0"
@@ -10597,9 +10571,9 @@
       }
     },
     "jwt-decode": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+      "integrity": "sha512-86GgN2vzfUu7m9Wcj63iUkuDzFNYFVmjeDm2GzWpUk+opB0pEpMsw6ePCMrhYkumz2C1ihqtZzOMAg7FiXcNoQ=="
     },
     "killable": {
       "version": "1.0.1",

--- a/ui-library-quickstart-composites/package-lock.json
+++ b/ui-library-quickstart-composites/package-lock.json
@@ -178,6 +178,26 @@
             "@azure/core-asynciterator-polyfill": "^1.0.0"
           }
         },
+        "@fluentui/react": {
+          "version": "8.17.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.17.4.tgz",
+          "integrity": "sha512-9H9kNL8p/hpVIXk0SPh7ExhX00HuBofbbeU6rnBqWbKfOdbV+iQ8INsvZWAE1JcWoaxP3iscZcM3N0ViH218HA==",
+          "requires": {
+            "@fluentui/date-time-utilities": "^8.1.2",
+            "@fluentui/font-icons-mdl2": "^8.1.2",
+            "@fluentui/foundation-legacy": "^8.1.2",
+            "@fluentui/merge-styles": "^8.1.2",
+            "@fluentui/react-focus": "^8.1.3",
+            "@fluentui/react-hooks": "^8.2.2",
+            "@fluentui/react-window-provider": "^2.1.2",
+            "@fluentui/set-version": "^8.1.2",
+            "@fluentui/style-utilities": "^8.1.2",
+            "@fluentui/theme": "^2.1.2",
+            "@fluentui/utilities": "^8.1.2",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
         "@opentelemetry/api": {
           "version": "1.0.0-rc.0",
           "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.0-rc.0.tgz",
@@ -1673,18 +1693,26 @@
       }
     },
     "@fluentui/date-time-utilities": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.5.2.tgz",
-      "integrity": "sha512-u540ACUdnC+Jms1DIHkho80eJmoCg/LtAzR4a/1Tum6PicxWv59UYp9Ba7qFbIw+mrjWnwX/2ZmBpqTy9Rgn7w==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.5.3.tgz",
+      "integrity": "sha512-jwbwcJlnerdjENIAfn/YHxl5H2sQruReOMWXWMgmvX0CmcbqsN9VBxBt+E35Tlr4Ds3MbGs60eyfZUIPpaB5RQ==",
       "requires": {
-        "@fluentui/set-version": "^8.2.2",
+        "@fluentui/set-version": "^8.2.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -1705,54 +1733,176 @@
       }
     },
     "@fluentui/font-icons-mdl2": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.5.2.tgz",
-      "integrity": "sha512-qDbZNiXVPx6X/Z2MpU3Oa2kWNSrk5+mG8ZRdH/thD7iwnV4l6DtBctNyXK/Cjq4EpG3eQQra8LBVxwOyDt0GqA==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.5.3.tgz",
+      "integrity": "sha512-C1P2fvaj8kka4tLJOoZPopq4kz2ZNCZ4ImGVvek8t7DOayOU2UoTKNoVKhNjynagbsLpwpOYA8Uzb4Ialx+/uQ==",
       "requires": {
-        "@fluentui/set-version": "^8.2.2",
-        "@fluentui/style-utilities": "^8.8.1",
-        "@fluentui/utilities": "^8.13.2",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/utilities": "^8.13.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/dom-utilities": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.3.tgz",
+          "integrity": "sha512-Ml/xwpTC6vb9lHHVAbSUD9jMbt9nVzV208D0FEoQn0c0+dP2vdMXSvXC/QHs/57B6JicttVQPuX6EcPwR3Mkpg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/merge-styles": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.4.tgz",
+          "integrity": "sha512-CeQIEcEgZu0cxqqyhJyTqySXoUL1vXfdWDJ8WMzchaNnhvOvoXISw8xXHpNXUtEn+HgPrcy9mHQwFcAc+jv3Wg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/style-utilities": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.2.tgz",
+          "integrity": "sha512-tef1nyWmgQTbETmvjQewxLfeJ+sJ21i3VzwBpK5qvj8MLwCHkMSBoDL7gXp6xCN2VSrQc0TkbykgUvRyJ2IReg==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/theme": "^2.6.18",
+            "@fluentui/utilities": "^8.13.3",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/theme": {
+          "version": "2.6.18",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.18.tgz",
+          "integrity": "sha512-NWiKCX62XDZ8FYjCN0Km4soFfqSyxqoTtxRVBVC5rujbkMbWyzyV/WpGz5ZNcrudhg/5LWNwILhyXxLRalG3mQ==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/utilities": {
+          "version": "8.13.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.3.tgz",
+          "integrity": "sha512-Nshe8pWKO/KngRx32EdhW5hvi5ZUWDR6hZcAGNgfLmXXQh3ZrTqAuLtmntv5PHvgbwz1qIsHfvqHgfAcHtoSpw==",
+          "requires": {
+            "@fluentui/dom-utilities": "^2.2.3",
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
     "@fluentui/foundation-legacy": {
-      "version": "8.2.22",
-      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.2.22.tgz",
-      "integrity": "sha512-wyv5KxmgG/Qivd0eUkQ4mpAdy3caPV9WrPd10MMw/0TGyCCrzq7+REZYVilRy1+VWQspQxWxRH7Kex9+LqPlKA==",
+      "version": "8.2.23",
+      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.2.23.tgz",
+      "integrity": "sha512-5idaKH7z0HKRAlfGH4BjqSlRKQh4yzVd5BWJ0MCPL20Rn6jmaIJSdjMHTrIfVhzLvSxn+7MQRV9a8S+AvIDUHQ==",
       "requires": {
-        "@fluentui/merge-styles": "^8.5.3",
-        "@fluentui/set-version": "^8.2.2",
-        "@fluentui/style-utilities": "^8.8.1",
-        "@fluentui/utilities": "^8.13.2",
+        "@fluentui/merge-styles": "^8.5.4",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/utilities": "^8.13.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/dom-utilities": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.3.tgz",
+          "integrity": "sha512-Ml/xwpTC6vb9lHHVAbSUD9jMbt9nVzV208D0FEoQn0c0+dP2vdMXSvXC/QHs/57B6JicttVQPuX6EcPwR3Mkpg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/merge-styles": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.4.tgz",
+          "integrity": "sha512-CeQIEcEgZu0cxqqyhJyTqySXoUL1vXfdWDJ8WMzchaNnhvOvoXISw8xXHpNXUtEn+HgPrcy9mHQwFcAc+jv3Wg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/style-utilities": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.2.tgz",
+          "integrity": "sha512-tef1nyWmgQTbETmvjQewxLfeJ+sJ21i3VzwBpK5qvj8MLwCHkMSBoDL7gXp6xCN2VSrQc0TkbykgUvRyJ2IReg==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/theme": "^2.6.18",
+            "@fluentui/utilities": "^8.13.3",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/theme": {
+          "version": "2.6.18",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.18.tgz",
+          "integrity": "sha512-NWiKCX62XDZ8FYjCN0Km4soFfqSyxqoTtxRVBVC5rujbkMbWyzyV/WpGz5ZNcrudhg/5LWNwILhyXxLRalG3mQ==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/utilities": {
+          "version": "8.13.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.3.tgz",
+          "integrity": "sha512-Nshe8pWKO/KngRx32EdhW5hvi5ZUWDR6hZcAGNgfLmXXQh3ZrTqAuLtmntv5PHvgbwz1qIsHfvqHgfAcHtoSpw==",
+          "requires": {
+            "@fluentui/dom-utilities": "^2.2.3",
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
     "@fluentui/keyboard-key": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.4.2.tgz",
-      "integrity": "sha512-6WdMrnFpY94uWefUGGRqO4WiS6R+Kso6/FR95SxXMuS6kfnjGJCHzywFGZcN5OU1fX067Zna4aPQ/nDwYMgBPw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.4.3.tgz",
+      "integrity": "sha512-uLiwx+UyXDN7tShv/s2NzDPtqeT/BZCHvY9yxEeb6LgEkos8TZvT5ep/7G8BpxA/SuBnviZ8xpDB5JObyZikqQ==",
       "requires": {
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -1773,29 +1923,111 @@
       }
     },
     "@fluentui/react": {
-      "version": "8.17.4",
-      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.17.4.tgz",
-      "integrity": "sha512-9H9kNL8p/hpVIXk0SPh7ExhX00HuBofbbeU6rnBqWbKfOdbV+iQ8INsvZWAE1JcWoaxP3iscZcM3N0ViH218HA==",
+      "version": "8.101.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.101.0.tgz",
+      "integrity": "sha512-kIVujMFy/vszhCO4GwxMhEIcQ9NCWm2GOqXjX0X/iLzR6g0yOUwzIfdTcKJrD8zpg1g41pANeYdpAnWrl/se6g==",
       "requires": {
-        "@fluentui/date-time-utilities": "^8.1.2",
-        "@fluentui/font-icons-mdl2": "^8.1.2",
-        "@fluentui/foundation-legacy": "^8.1.2",
-        "@fluentui/merge-styles": "^8.1.2",
-        "@fluentui/react-focus": "^8.1.3",
-        "@fluentui/react-hooks": "^8.2.2",
-        "@fluentui/react-window-provider": "^2.1.2",
-        "@fluentui/set-version": "^8.1.2",
-        "@fluentui/style-utilities": "^8.1.2",
-        "@fluentui/theme": "^2.1.2",
-        "@fluentui/utilities": "^8.1.2",
+        "@fluentui/date-time-utilities": "^8.5.3",
+        "@fluentui/font-icons-mdl2": "^8.5.3",
+        "@fluentui/foundation-legacy": "^8.2.23",
+        "@fluentui/merge-styles": "^8.5.4",
+        "@fluentui/react-focus": "^8.8.9",
+        "@fluentui/react-hooks": "^8.6.13",
+        "@fluentui/react-portal-compat-context": "^9.0.3",
+        "@fluentui/react-window-provider": "^2.2.4",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/theme": "^2.6.18",
+        "@fluentui/utilities": "^8.13.3",
         "@microsoft/load-themed-styles": "^1.10.26",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/dom-utilities": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.3.tgz",
+          "integrity": "sha512-Ml/xwpTC6vb9lHHVAbSUD9jMbt9nVzV208D0FEoQn0c0+dP2vdMXSvXC/QHs/57B6JicttVQPuX6EcPwR3Mkpg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/merge-styles": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.4.tgz",
+          "integrity": "sha512-CeQIEcEgZu0cxqqyhJyTqySXoUL1vXfdWDJ8WMzchaNnhvOvoXISw8xXHpNXUtEn+HgPrcy9mHQwFcAc+jv3Wg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/react-hooks": {
+          "version": "8.6.13",
+          "resolved": "https://registry.npmjs.org/@fluentui/react-hooks/-/react-hooks-8.6.13.tgz",
+          "integrity": "sha512-RAbVuwzX40czyNNkVpRFYKST2dX+PL0qIT5LB92SWqhEfyZjMOcOeg/YaEoLFZKNOVilAfUItSCD6HzurO4aLA==",
+          "requires": {
+            "@fluentui/react-window-provider": "^2.2.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/react-window-provider": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-2.2.4.tgz",
+          "integrity": "sha512-tCiIGQSILSipcn8DwwRgYq5IMtwBKiSQ+/cVRNq54cJZoq5ie/kMGFpldZ+vREDbM8wjmO3eNgNi63A3QRx39g==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/style-utilities": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.2.tgz",
+          "integrity": "sha512-tef1nyWmgQTbETmvjQewxLfeJ+sJ21i3VzwBpK5qvj8MLwCHkMSBoDL7gXp6xCN2VSrQc0TkbykgUvRyJ2IReg==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/theme": "^2.6.18",
+            "@fluentui/utilities": "^8.13.3",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/theme": {
+          "version": "2.6.18",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.18.tgz",
+          "integrity": "sha512-NWiKCX62XDZ8FYjCN0Km4soFfqSyxqoTtxRVBVC5rujbkMbWyzyV/WpGz5ZNcrudhg/5LWNwILhyXxLRalG3mQ==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/utilities": {
+          "version": "8.13.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.3.tgz",
+          "integrity": "sha512-Nshe8pWKO/KngRx32EdhW5hvi5ZUWDR6hZcAGNgfLmXXQh3ZrTqAuLtmntv5PHvgbwz1qIsHfvqHgfAcHtoSpw==",
+          "requires": {
+            "@fluentui/dom-utilities": "^2.2.3",
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -1863,22 +2095,83 @@
       }
     },
     "@fluentui/react-focus": {
-      "version": "8.8.8",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.8.8.tgz",
-      "integrity": "sha512-N4JmmduWk50tIGTH6kYTDa1HJfJ9qzGztbmo7HEh+gzHLwHDkL0GOV5+VWfwPuBcUqD1eKP4fz/e/gCBswBShg==",
+      "version": "8.8.9",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.8.9.tgz",
+      "integrity": "sha512-lYixFOZ2OjULcWhD3MppxzAt6aImkhNQiNtUJzswBV1xmYvkpYOxXK2hxf3/CeRAFijcmuAIvwg1rRgYBfRxxA==",
       "requires": {
-        "@fluentui/keyboard-key": "^0.4.2",
-        "@fluentui/merge-styles": "^8.5.3",
-        "@fluentui/set-version": "^8.2.2",
-        "@fluentui/style-utilities": "^8.8.1",
-        "@fluentui/utilities": "^8.13.2",
+        "@fluentui/keyboard-key": "^0.4.3",
+        "@fluentui/merge-styles": "^8.5.4",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/utilities": "^8.13.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/dom-utilities": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.3.tgz",
+          "integrity": "sha512-Ml/xwpTC6vb9lHHVAbSUD9jMbt9nVzV208D0FEoQn0c0+dP2vdMXSvXC/QHs/57B6JicttVQPuX6EcPwR3Mkpg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/merge-styles": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.4.tgz",
+          "integrity": "sha512-CeQIEcEgZu0cxqqyhJyTqySXoUL1vXfdWDJ8WMzchaNnhvOvoXISw8xXHpNXUtEn+HgPrcy9mHQwFcAc+jv3Wg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/style-utilities": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.2.tgz",
+          "integrity": "sha512-tef1nyWmgQTbETmvjQewxLfeJ+sJ21i3VzwBpK5qvj8MLwCHkMSBoDL7gXp6xCN2VSrQc0TkbykgUvRyJ2IReg==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/theme": "^2.6.18",
+            "@fluentui/utilities": "^8.13.3",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/theme": {
+          "version": "2.6.18",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.18.tgz",
+          "integrity": "sha512-NWiKCX62XDZ8FYjCN0Km4soFfqSyxqoTtxRVBVC5rujbkMbWyzyV/WpGz5ZNcrudhg/5LWNwILhyXxLRalG3mQ==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/utilities": {
+          "version": "8.13.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.3.tgz",
+          "integrity": "sha512-Nshe8pWKO/KngRx32EdhW5hvi5ZUWDR6hZcAGNgfLmXXQh3ZrTqAuLtmntv5PHvgbwz1qIsHfvqHgfAcHtoSpw==",
+          "requires": {
+            "@fluentui/dom-utilities": "^2.2.3",
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -1985,6 +2278,21 @@
       "requires": {
         "@babel/runtime": "^7.10.4",
         "@fluentui/styles": "^0.61.0"
+      }
+    },
+    "@fluentui/react-portal-compat-context": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-portal-compat-context/-/react-portal-compat-context-9.0.3.tgz",
+      "integrity": "sha512-XZczqvKJflK6jFv6RekFXzZFnxvd1tBbIsRFs6JMX8zNqMO7ZQJ6Yfee5LLs6HnZE5BKowE7jIUMOTH9yOmyJg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@fluentui/react-proptypes": {

--- a/ui-library-quickstart-composites/package-lock.json
+++ b/ui-library-quickstart-composites/package-lock.json
@@ -20,11 +20,11 @@
       }
     },
     "@azure/communication-calling": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@azure/communication-calling/-/communication-calling-1.4.4.tgz",
-      "integrity": "sha512-uWzULqnXB7pMIEH8x1mwwT45ncPfAryfoKxd4BtbcL1C3ckMknk/5gP3Ov2/V5DJkoOO3I6A4D1n05eSFRy+zA==",
+      "version": "1.6.1-beta.1",
+      "resolved": "https://registry.npmjs.org/@azure/communication-calling/-/communication-calling-1.6.1-beta.1.tgz",
+      "integrity": "sha512-VWMcKU1taJ8E9n3bsY8XlatKoTSkKCMYPRGusEC2UfjS/eGlRPRZ7sk1fZEESvCny6Y4Q7dKZv4OqbW5e6VfeQ==",
       "requires": {
-        "@azure/communication-common": "^1.0.0",
+        "@azure/communication-common": "^2.0.0",
         "@azure/logger": "^1.0.2"
       }
     },
@@ -75,39 +75,49 @@
       }
     },
     "@azure/communication-common": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/communication-common/-/communication-common-1.1.0.tgz",
-      "integrity": "sha512-vqTtzDtb4NG3LWoWoqlOOJApZRRIIImNUKlGyTa6c1YC+v5A7UEOL9TX8NRDxvFVUF2wDHsSnkhLBVBgkcAhIQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/communication-common/-/communication-common-2.2.0.tgz",
+      "integrity": "sha512-92zGSs+qwWHEqCRIGAudYhPgnUT270Y3Mb2xuYH253IF3da74A+GyNhSEma0Zy6qHb+c5oHkh4Ijr2ndhrBQ2A==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-auth": "^1.3.0",
-        "@azure/core-http": "^2.0.0",
-        "@azure/core-tracing": "1.0.0-preview.13",
+        "@azure/core-rest-pipeline": "^1.3.2",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.0.0",
         "events": "^3.0.0",
-        "jwt-decode": "~2.2.0",
+        "jwt-decode": "^3.1.2",
         "tslib": "^2.2.0"
       },
       "dependencies": {
+        "@azure/core-tracing": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
+          "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
+          "requires": {
+            "tslib": "^2.2.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
     "@azure/communication-react": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@azure/communication-react/-/communication-react-1.3.1.tgz",
-      "integrity": "sha512-TybRu2xLQdzdRN3EyyEwArSg0Akw3So5W/RjoL3ifMLj5TPzeSXvf8KQtF7pBW+pHxrfoDvu3fMiCxx2sUw5fQ==",
+      "version": "1.3.2-beta.1",
+      "resolved": "https://registry.npmjs.org/@azure/communication-react/-/communication-react-1.3.2-beta.1.tgz",
+      "integrity": "sha512-zTEQWhydXiccDcykCJ+sXDhqmCASDTFCAfxkEz7PeoAtc8bSGAbDDn++q5AMcG5aYL8Am6HhkyZxlaZY9PLA7A==",
       "requires": {
         "@azure/communication-common": "2.0.0",
-        "@azure/core-http": "1.2.4",
+        "@azure/core-client": "1.3.0",
         "@azure/core-paging": "~1.1.3",
+        "@azure/core-rest-pipeline": "~1.9.2",
         "@azure/logger": "1.0.3",
-        "@fluentui/react": "~8.17.2",
+        "@fluentui/react": "~8.62.4",
         "@fluentui/react-file-type-icons": "~8.5.8",
         "@fluentui/react-hooks": "~8.3.8",
-        "@fluentui/react-icons": "~1.1.137",
+        "@fluentui/react-icons": "~1.1.145",
         "@fluentui/react-northstar": "0.61.0",
         "@fluentui/react-window-provider": "~2.2.0",
         "copy-to-clipboard": "~3.3.1",
@@ -136,38 +146,17 @@
             "tslib": "^2.2.0"
           }
         },
-        "@azure/core-http": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.2.4.tgz",
-          "integrity": "sha512-cNumz3ckyFZY5zWOgcTHSO7AKRVwxbodG8WfcEGcdH+ZJL3KvJEI/vN58H6xk5v3ijulU2x/WPGJqrMVvcI79A==",
+        "@azure/core-client": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.3.0.tgz",
+          "integrity": "sha512-4ricu3aM1TQP2vglBcvFX8KgbWVe+7hl1jVAw6BzIGG4CTAvO3ygDS6th3O+zFwGN9xkgXFHa7Tp3u9za8ciIA==",
           "requires": {
             "@azure/abort-controller": "^1.0.0",
             "@azure/core-asynciterator-polyfill": "^1.0.0",
             "@azure/core-auth": "^1.3.0",
-            "@azure/core-tracing": "1.0.0-preview.11",
-            "@azure/logger": "^1.0.0",
-            "@types/node-fetch": "^2.5.0",
-            "@types/tunnel": "^0.0.1",
-            "form-data": "^3.0.0",
-            "node-fetch": "^2.6.0",
-            "process": "^0.11.10",
-            "tough-cookie": "^4.0.0",
-            "tslib": "^2.0.0",
-            "tunnel": "^0.0.6",
-            "uuid": "^8.3.0",
-            "xml2js": "^0.4.19"
-          },
-          "dependencies": {
-            "@azure/core-tracing": {
-              "version": "1.0.0-preview.11",
-              "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.11.tgz",
-              "integrity": "sha512-frF0pJc9HTmKncVokhBxCqipjbql02DThQ1ZJ9wLi7SDMLdPAFyDI5xZNzX5guLz+/DtPkY+SGK2li9FIXqshQ==",
-              "requires": {
-                "@opencensus/web-types": "0.0.7",
-                "@opentelemetry/api": "1.0.0-rc.0",
-                "tslib": "^2.0.0"
-              }
-            }
+            "@azure/core-rest-pipeline": "^1.1.0",
+            "@azure/core-tracing": "1.0.0-preview.13",
+            "tslib": "^2.2.0"
           }
         },
         "@azure/core-paging": {
@@ -178,17 +167,37 @@
             "@azure/core-asynciterator-polyfill": "^1.0.0"
           }
         },
-        "@opentelemetry/api": {
-          "version": "1.0.0-rc.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.0-rc.0.tgz",
-          "integrity": "sha512-iXKByCMfrlO5S6Oh97BuM56tM2cIBB0XsL/vWF/AtJrJEKx4MC/Xdu0xDsGXMGcNWpqF7ujMsjjnp0+UHBwnDQ=="
-        },
-        "@types/tunnel": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
-          "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
+        "@fluentui/react": {
+          "version": "8.62.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.62.4.tgz",
+          "integrity": "sha512-vwN6fg5n8xxynnW0Cmjk4Qao+6OE/bOF8k1hoMdufkKTJx1VpRa1SZHMgHCh0/kXoXWQyBeyetcUOPjXw/sPlQ==",
           "requires": {
-            "@types/node": "*"
+            "@fluentui/date-time-utilities": "^8.5.0",
+            "@fluentui/font-icons-mdl2": "^8.2.5",
+            "@fluentui/foundation-legacy": "^8.2.5",
+            "@fluentui/merge-styles": "^8.5.0",
+            "@fluentui/react-focus": "^8.5.6",
+            "@fluentui/react-hooks": "^8.5.3",
+            "@fluentui/react-window-provider": "^2.2.0",
+            "@fluentui/set-version": "^8.2.0",
+            "@fluentui/style-utilities": "^8.6.5",
+            "@fluentui/theme": "^2.6.4",
+            "@fluentui/utilities": "^8.8.1",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          },
+          "dependencies": {
+            "@fluentui/react-hooks": {
+              "version": "8.6.13",
+              "resolved": "https://registry.npmjs.org/@fluentui/react-hooks/-/react-hooks-8.6.13.tgz",
+              "integrity": "sha512-RAbVuwzX40czyNNkVpRFYKST2dX+PL0qIT5LB92SWqhEfyZjMOcOeg/YaEoLFZKNOVilAfUItSCD6HzurO4aLA==",
+              "requires": {
+                "@fluentui/react-window-provider": "^2.2.4",
+                "@fluentui/set-version": "^8.2.3",
+                "@fluentui/utilities": "^8.13.3",
+                "tslib": "^2.1.0"
+              }
+            }
           }
         },
         "immer": {
@@ -196,20 +205,15 @@
           "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
           "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ=="
         },
-        "jwt-decode": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-          "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
-        },
         "nanoid": {
           "version": "3.1.32",
           "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.32.tgz",
           "integrity": "sha512-F8mf7R3iT9bvThBoW4tGXhXFHCctyCiUUPrWF8WaTqa3h96d9QybkSeba43XVOOE3oiLfkVDe4bT8MeGmkrTxw=="
         },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -1673,129 +1677,141 @@
       }
     },
     "@fluentui/date-time-utilities": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.5.2.tgz",
-      "integrity": "sha512-u540ACUdnC+Jms1DIHkho80eJmoCg/LtAzR4a/1Tum6PicxWv59UYp9Ba7qFbIw+mrjWnwX/2ZmBpqTy9Rgn7w==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.5.3.tgz",
+      "integrity": "sha512-jwbwcJlnerdjENIAfn/YHxl5H2sQruReOMWXWMgmvX0CmcbqsN9VBxBt+E35Tlr4Ds3MbGs60eyfZUIPpaB5RQ==",
       "requires": {
-        "@fluentui/set-version": "^8.2.2",
+        "@fluentui/set-version": "^8.2.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
     "@fluentui/dom-utilities": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.2.tgz",
-      "integrity": "sha512-puklLc6Jvg279OGagqkSfuHML6ckBhw3gJakdvIZHKeJiduh+34U4Finl3K24yBSXzG2WsN+LwLTd1Vcociy+g==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.3.tgz",
+      "integrity": "sha512-Ml/xwpTC6vb9lHHVAbSUD9jMbt9nVzV208D0FEoQn0c0+dP2vdMXSvXC/QHs/57B6JicttVQPuX6EcPwR3Mkpg==",
       "requires": {
-        "@fluentui/set-version": "^8.2.2",
+        "@fluentui/set-version": "^8.2.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
     "@fluentui/font-icons-mdl2": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.5.2.tgz",
-      "integrity": "sha512-qDbZNiXVPx6X/Z2MpU3Oa2kWNSrk5+mG8ZRdH/thD7iwnV4l6DtBctNyXK/Cjq4EpG3eQQra8LBVxwOyDt0GqA==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.5.3.tgz",
+      "integrity": "sha512-C1P2fvaj8kka4tLJOoZPopq4kz2ZNCZ4ImGVvek8t7DOayOU2UoTKNoVKhNjynagbsLpwpOYA8Uzb4Ialx+/uQ==",
       "requires": {
-        "@fluentui/set-version": "^8.2.2",
-        "@fluentui/style-utilities": "^8.8.1",
-        "@fluentui/utilities": "^8.13.2",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/utilities": "^8.13.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
     "@fluentui/foundation-legacy": {
-      "version": "8.2.22",
-      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.2.22.tgz",
-      "integrity": "sha512-wyv5KxmgG/Qivd0eUkQ4mpAdy3caPV9WrPd10MMw/0TGyCCrzq7+REZYVilRy1+VWQspQxWxRH7Kex9+LqPlKA==",
+      "version": "8.2.23",
+      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.2.23.tgz",
+      "integrity": "sha512-5idaKH7z0HKRAlfGH4BjqSlRKQh4yzVd5BWJ0MCPL20Rn6jmaIJSdjMHTrIfVhzLvSxn+7MQRV9a8S+AvIDUHQ==",
       "requires": {
-        "@fluentui/merge-styles": "^8.5.3",
-        "@fluentui/set-version": "^8.2.2",
-        "@fluentui/style-utilities": "^8.8.1",
-        "@fluentui/utilities": "^8.13.2",
+        "@fluentui/merge-styles": "^8.5.4",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/utilities": "^8.13.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
     "@fluentui/keyboard-key": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.4.2.tgz",
-      "integrity": "sha512-6WdMrnFpY94uWefUGGRqO4WiS6R+Kso6/FR95SxXMuS6kfnjGJCHzywFGZcN5OU1fX067Zna4aPQ/nDwYMgBPw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.4.3.tgz",
+      "integrity": "sha512-uLiwx+UyXDN7tShv/s2NzDPtqeT/BZCHvY9yxEeb6LgEkos8TZvT5ep/7G8BpxA/SuBnviZ8xpDB5JObyZikqQ==",
       "requires": {
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
     "@fluentui/merge-styles": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.3.tgz",
-      "integrity": "sha512-bHWftN3zTp1bbBfmAEH8YK9UURWj2mffw7b7VaW2Og1qxwv3GMSza1cyv/d3EVqpMJ8AVwFv3mbi9p1ieMN9mw==",
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.4.tgz",
+      "integrity": "sha512-CeQIEcEgZu0cxqqyhJyTqySXoUL1vXfdWDJ8WMzchaNnhvOvoXISw8xXHpNXUtEn+HgPrcy9mHQwFcAc+jv3Wg==",
       "requires": {
-        "@fluentui/set-version": "^8.2.2",
+        "@fluentui/set-version": "^8.2.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
     "@fluentui/react": {
-      "version": "8.17.4",
-      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.17.4.tgz",
-      "integrity": "sha512-9H9kNL8p/hpVIXk0SPh7ExhX00HuBofbbeU6rnBqWbKfOdbV+iQ8INsvZWAE1JcWoaxP3iscZcM3N0ViH218HA==",
+      "version": "8.101.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.101.0.tgz",
+      "integrity": "sha512-kIVujMFy/vszhCO4GwxMhEIcQ9NCWm2GOqXjX0X/iLzR6g0yOUwzIfdTcKJrD8zpg1g41pANeYdpAnWrl/se6g==",
       "requires": {
-        "@fluentui/date-time-utilities": "^8.1.2",
-        "@fluentui/font-icons-mdl2": "^8.1.2",
-        "@fluentui/foundation-legacy": "^8.1.2",
-        "@fluentui/merge-styles": "^8.1.2",
-        "@fluentui/react-focus": "^8.1.3",
-        "@fluentui/react-hooks": "^8.2.2",
-        "@fluentui/react-window-provider": "^2.1.2",
-        "@fluentui/set-version": "^8.1.2",
-        "@fluentui/style-utilities": "^8.1.2",
-        "@fluentui/theme": "^2.1.2",
-        "@fluentui/utilities": "^8.1.2",
+        "@fluentui/date-time-utilities": "^8.5.3",
+        "@fluentui/font-icons-mdl2": "^8.5.3",
+        "@fluentui/foundation-legacy": "^8.2.23",
+        "@fluentui/merge-styles": "^8.5.4",
+        "@fluentui/react-focus": "^8.8.9",
+        "@fluentui/react-hooks": "^8.6.13",
+        "@fluentui/react-portal-compat-context": "^9.0.3",
+        "@fluentui/react-window-provider": "^2.2.4",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/theme": "^2.6.18",
+        "@fluentui/utilities": "^8.13.3",
         "@microsoft/load-themed-styles": "^1.10.26",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/react-hooks": {
+          "version": "8.6.13",
+          "resolved": "https://registry.npmjs.org/@fluentui/react-hooks/-/react-hooks-8.6.13.tgz",
+          "integrity": "sha512-RAbVuwzX40czyNNkVpRFYKST2dX+PL0qIT5LB92SWqhEfyZjMOcOeg/YaEoLFZKNOVilAfUItSCD6HzurO4aLA==",
+          "requires": {
+            "@fluentui/react-window-provider": "^2.2.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -1856,29 +1872,29 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
     "@fluentui/react-focus": {
-      "version": "8.8.8",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.8.8.tgz",
-      "integrity": "sha512-N4JmmduWk50tIGTH6kYTDa1HJfJ9qzGztbmo7HEh+gzHLwHDkL0GOV5+VWfwPuBcUqD1eKP4fz/e/gCBswBShg==",
+      "version": "8.8.9",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.8.9.tgz",
+      "integrity": "sha512-lYixFOZ2OjULcWhD3MppxzAt6aImkhNQiNtUJzswBV1xmYvkpYOxXK2hxf3/CeRAFijcmuAIvwg1rRgYBfRxxA==",
       "requires": {
-        "@fluentui/keyboard-key": "^0.4.2",
-        "@fluentui/merge-styles": "^8.5.3",
-        "@fluentui/set-version": "^8.2.2",
-        "@fluentui/style-utilities": "^8.8.1",
-        "@fluentui/utilities": "^8.13.2",
+        "@fluentui/keyboard-key": "^0.4.3",
+        "@fluentui/merge-styles": "^8.5.4",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/utilities": "^8.13.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -1894,9 +1910,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -1987,6 +2003,21 @@
         "@fluentui/styles": "^0.61.0"
       }
     },
+    "@fluentui/react-portal-compat-context": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-portal-compat-context/-/react-portal-compat-context-9.0.3.tgz",
+      "integrity": "sha512-XZczqvKJflK6jFv6RekFXzZFnxvd1tBbIsRFs6JMX8zNqMO7ZQJ6Yfee5LLs6HnZE5BKowE7jIUMOTH9yOmyJg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
+      }
+    },
     "@fluentui/react-proptypes": {
       "version": "0.61.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-proptypes/-/react-proptypes-0.61.0.tgz",
@@ -1998,33 +2029,33 @@
       }
     },
     "@fluentui/react-window-provider": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-2.2.3.tgz",
-      "integrity": "sha512-uJztbyMu7x/cSYnJ0Rbmult/t22zFnQG20Jtlhmh5/g+M8QiF/T7xz9dkNe4Hon4KmpqnZpd8ds4nmX0fwxODg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-2.2.4.tgz",
+      "integrity": "sha512-tCiIGQSILSipcn8DwwRgYq5IMtwBKiSQ+/cVRNq54cJZoq5ie/kMGFpldZ+vREDbM8wjmO3eNgNi63A3QRx39g==",
       "requires": {
-        "@fluentui/set-version": "^8.2.2",
+        "@fluentui/set-version": "^8.2.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
     "@fluentui/set-version": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.2.tgz",
-      "integrity": "sha512-Vg20KZ0ufgWjxx6GFbqC5wiVxXZDUWgNT0r0By/Eyj4bUSb1jG6lmf5z1oY1dUX0YS6Cp5e6GnvbNdXg5E7orA==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+      "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
       "requires": {
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -2037,22 +2068,22 @@
       }
     },
     "@fluentui/style-utilities": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.1.tgz",
-      "integrity": "sha512-asOdSI9+9qgnvpriRuAluREM94iyJJOONA+yZvJiYkVttgFRt77xWrabFjuEbX4pPCmqHhmA0d7dz8zPKgV7cA==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.2.tgz",
+      "integrity": "sha512-tef1nyWmgQTbETmvjQewxLfeJ+sJ21i3VzwBpK5qvj8MLwCHkMSBoDL7gXp6xCN2VSrQc0TkbykgUvRyJ2IReg==",
       "requires": {
-        "@fluentui/merge-styles": "^8.5.3",
-        "@fluentui/set-version": "^8.2.2",
-        "@fluentui/theme": "^2.6.17",
-        "@fluentui/utilities": "^8.13.2",
+        "@fluentui/merge-styles": "^8.5.4",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/theme": "^2.6.18",
+        "@fluentui/utilities": "^8.13.3",
         "@microsoft/load-themed-styles": "^1.10.26",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -2067,38 +2098,38 @@
       }
     },
     "@fluentui/theme": {
-      "version": "2.6.17",
-      "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.17.tgz",
-      "integrity": "sha512-9pxMhOugX3bwY86TresiR6UQNszylD4oiVCAj5s5li7zGos+psdOMrmz9LykIEn1mbAofT/XvRCYfiKECtHEpA==",
+      "version": "2.6.18",
+      "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.18.tgz",
+      "integrity": "sha512-NWiKCX62XDZ8FYjCN0Km4soFfqSyxqoTtxRVBVC5rujbkMbWyzyV/WpGz5ZNcrudhg/5LWNwILhyXxLRalG3mQ==",
       "requires": {
-        "@fluentui/merge-styles": "^8.5.3",
-        "@fluentui/set-version": "^8.2.2",
-        "@fluentui/utilities": "^8.13.2",
+        "@fluentui/merge-styles": "^8.5.4",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/utilities": "^8.13.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
     "@fluentui/utilities": {
-      "version": "8.13.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.2.tgz",
-      "integrity": "sha512-0AHJBMyYVI7vFChXdPynFf32IYB2y6z4EB5ACzW8UkPFrwkHncbj5pPPE24MCbV7jYR49YrHn9eLY38B+H4iiw==",
+      "version": "8.13.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.3.tgz",
+      "integrity": "sha512-Nshe8pWKO/KngRx32EdhW5hvi5ZUWDR6hZcAGNgfLmXXQh3ZrTqAuLtmntv5PHvgbwz1qIsHfvqHgfAcHtoSpw==",
       "requires": {
-        "@fluentui/dom-utilities": "^2.2.2",
-        "@fluentui/merge-styles": "^8.5.3",
-        "@fluentui/set-version": "^8.2.2",
+        "@fluentui/dom-utilities": "^2.2.3",
+        "@fluentui/merge-styles": "^8.5.4",
+        "@fluentui/set-version": "^8.2.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -2716,11 +2747,6 @@
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
       }
-    },
-    "@opencensus/web-types": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.7.tgz",
-      "integrity": "sha512-xB+w7ZDAu3YBzqH44rCmG9/RlrOmFuDPt/bpf17eJr8eZSrLt7nc7LnWdxM9Mmoj/YKMHpxRg28txu3TcpiL+g=="
     },
     "@opentelemetry/api": {
       "version": "1.2.0",
@@ -3482,9 +3508,9 @@
       }
     },
     "@uifabric/merge-styles": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.20.1.tgz",
-      "integrity": "sha512-LaxbbAGGh/X4x9gwd6kMFIiJKOczy0kHJ1/16b2CAs9De+Ra0mxdTfO9yHbLXKXOvNJcx0mzwaYMDrgBG7cT8A==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.20.2.tgz",
+      "integrity": "sha512-cJy8hW9smlWOKgz9xSDMCz/A0yMl4mdo466pcGlIOn84vz+e94grfA7OoTuTzg3Cl0Gj6ODBSf1o0ZwIXYL1Xg==",
       "requires": {
         "@uifabric/set-version": "^7.0.24",
         "tslib": "^1.10.0"
@@ -3499,12 +3525,12 @@
       }
     },
     "@uifabric/utilities": {
-      "version": "7.38.1",
-      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.38.1.tgz",
-      "integrity": "sha512-AdNsDbiARDEtLA9QLGzCYZA7nVKuS7etV7ANvpJ9rko3ApyudRrKZBdHAckd+r8yMCQzg77v8tCfiam2A4jN8g==",
+      "version": "7.38.2",
+      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.38.2.tgz",
+      "integrity": "sha512-5yM4sm142VEBg3/Q5SFheBXqnrZi9CNF5rjHNoex0GgGtG3AHPuS7U8gjm+/Io1MvbuCrn6lyyIw0MDvh1Ebkw==",
       "requires": {
         "@fluentui/dom-utilities": "^1.1.2",
-        "@uifabric/merge-styles": "^7.20.1",
+        "@uifabric/merge-styles": "^7.20.2",
         "@uifabric/set-version": "^7.0.24",
         "prop-types": "^15.7.2",
         "tslib": "^1.10.0"
@@ -10571,9 +10597,9 @@
       }
     },
     "jwt-decode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
-      "integrity": "sha512-86GgN2vzfUu7m9Wcj63iUkuDzFNYFVmjeDm2GzWpUk+opB0pEpMsw6ePCMrhYkumz2C1ihqtZzOMAg7FiXcNoQ=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "killable": {
       "version": "1.0.1",

--- a/ui-library-quickstart-composites/package.json
+++ b/ui-library-quickstart-composites/package.json
@@ -3,9 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@azure/communication-calling": "1.4.4",
+    "@azure/communication-calling": "1.6.1-beta.1",
     "@azure/communication-chat": "1.2.0",
-    "@azure/communication-react": "1.3.1",
+    "@azure/communication-react": "1.3.2-beta.1",
+    "@fluentui/react": "8.101.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",

--- a/ui-library-quickstart-composites/package.json
+++ b/ui-library-quickstart-composites/package.json
@@ -3,10 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@azure/communication-calling": "1.6.1-beta.1",
+    "@azure/communication-calling": "1.4.4",
     "@azure/communication-chat": "1.2.0",
-    "@azure/communication-react": "1.3.2-beta.1",
-    "@fluentui/react": "8.101.0",
+    "@azure/communication-react": "1.3.1",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",

--- a/ui-library-quickstart-composites/package.json
+++ b/ui-library-quickstart-composites/package.json
@@ -6,6 +6,7 @@
     "@azure/communication-calling": "1.4.4",
     "@azure/communication-chat": "1.2.0",
     "@azure/communication-react": "1.3.1",
+    "@fluentui/react": "8.101.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",

--- a/ui-library-quickstart-composites/src/App.tsx
+++ b/ui-library-quickstart-composites/src/App.tsx
@@ -18,7 +18,6 @@ import React, {
 } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { ChatClient } from '@azure/communication-chat';
-import { initializeIcons } from '@fluentui/react';
 
 /**
  * Authentication information needed for your client application to use
@@ -41,8 +40,6 @@ const TOKEN = '<Azure Communication Services Access Token>';
  * goes through your authentication flow.
  */
 const DISPLAY_NAME = '<Display Name>';
-
-initializeIcons();
 
 /**
  * Entry point of your application.

--- a/ui-library-quickstart-composites/src/App.tsx
+++ b/ui-library-quickstart-composites/src/App.tsx
@@ -18,6 +18,7 @@ import React, {
 } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { ChatClient } from '@azure/communication-chat';
+import { initializeIcons } from '@fluentui/react';
 
 /**
  * Authentication information needed for your client application to use
@@ -40,6 +41,8 @@ const TOKEN = '<Azure Communication Services Access Token>';
  * goes through your authentication flow.
  */
 const DISPLAY_NAME = '<Display Name>';
+
+initializeIcons();
 
 /**
  * Entry point of your application.

--- a/ui-library-quickstart-ui-components/package-lock.json
+++ b/ui-library-quickstart-ui-components/package-lock.json
@@ -178,6 +178,26 @@
             "@azure/core-asynciterator-polyfill": "^1.0.0"
           }
         },
+        "@fluentui/react": {
+          "version": "8.17.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.17.4.tgz",
+          "integrity": "sha512-9H9kNL8p/hpVIXk0SPh7ExhX00HuBofbbeU6rnBqWbKfOdbV+iQ8INsvZWAE1JcWoaxP3iscZcM3N0ViH218HA==",
+          "requires": {
+            "@fluentui/date-time-utilities": "^8.1.2",
+            "@fluentui/font-icons-mdl2": "^8.1.2",
+            "@fluentui/foundation-legacy": "^8.1.2",
+            "@fluentui/merge-styles": "^8.1.2",
+            "@fluentui/react-focus": "^8.1.3",
+            "@fluentui/react-hooks": "^8.2.2",
+            "@fluentui/react-window-provider": "^2.1.2",
+            "@fluentui/set-version": "^8.1.2",
+            "@fluentui/style-utilities": "^8.1.2",
+            "@fluentui/theme": "^2.1.2",
+            "@fluentui/utilities": "^8.1.2",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
         "@opentelemetry/api": {
           "version": "1.0.0-rc.0",
           "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.0-rc.0.tgz",
@@ -1717,18 +1737,26 @@
       }
     },
     "@fluentui/date-time-utilities": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.5.2.tgz",
-      "integrity": "sha512-u540ACUdnC+Jms1DIHkho80eJmoCg/LtAzR4a/1Tum6PicxWv59UYp9Ba7qFbIw+mrjWnwX/2ZmBpqTy9Rgn7w==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.5.3.tgz",
+      "integrity": "sha512-jwbwcJlnerdjENIAfn/YHxl5H2sQruReOMWXWMgmvX0CmcbqsN9VBxBt+E35Tlr4Ds3MbGs60eyfZUIPpaB5RQ==",
       "requires": {
-        "@fluentui/set-version": "^8.2.2",
+        "@fluentui/set-version": "^8.2.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -1749,54 +1777,176 @@
       }
     },
     "@fluentui/font-icons-mdl2": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.5.2.tgz",
-      "integrity": "sha512-qDbZNiXVPx6X/Z2MpU3Oa2kWNSrk5+mG8ZRdH/thD7iwnV4l6DtBctNyXK/Cjq4EpG3eQQra8LBVxwOyDt0GqA==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.5.3.tgz",
+      "integrity": "sha512-C1P2fvaj8kka4tLJOoZPopq4kz2ZNCZ4ImGVvek8t7DOayOU2UoTKNoVKhNjynagbsLpwpOYA8Uzb4Ialx+/uQ==",
       "requires": {
-        "@fluentui/set-version": "^8.2.2",
-        "@fluentui/style-utilities": "^8.8.1",
-        "@fluentui/utilities": "^8.13.2",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/utilities": "^8.13.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/dom-utilities": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.3.tgz",
+          "integrity": "sha512-Ml/xwpTC6vb9lHHVAbSUD9jMbt9nVzV208D0FEoQn0c0+dP2vdMXSvXC/QHs/57B6JicttVQPuX6EcPwR3Mkpg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/merge-styles": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.4.tgz",
+          "integrity": "sha512-CeQIEcEgZu0cxqqyhJyTqySXoUL1vXfdWDJ8WMzchaNnhvOvoXISw8xXHpNXUtEn+HgPrcy9mHQwFcAc+jv3Wg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/style-utilities": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.2.tgz",
+          "integrity": "sha512-tef1nyWmgQTbETmvjQewxLfeJ+sJ21i3VzwBpK5qvj8MLwCHkMSBoDL7gXp6xCN2VSrQc0TkbykgUvRyJ2IReg==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/theme": "^2.6.18",
+            "@fluentui/utilities": "^8.13.3",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/theme": {
+          "version": "2.6.18",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.18.tgz",
+          "integrity": "sha512-NWiKCX62XDZ8FYjCN0Km4soFfqSyxqoTtxRVBVC5rujbkMbWyzyV/WpGz5ZNcrudhg/5LWNwILhyXxLRalG3mQ==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/utilities": {
+          "version": "8.13.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.3.tgz",
+          "integrity": "sha512-Nshe8pWKO/KngRx32EdhW5hvi5ZUWDR6hZcAGNgfLmXXQh3ZrTqAuLtmntv5PHvgbwz1qIsHfvqHgfAcHtoSpw==",
+          "requires": {
+            "@fluentui/dom-utilities": "^2.2.3",
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
     "@fluentui/foundation-legacy": {
-      "version": "8.2.22",
-      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.2.22.tgz",
-      "integrity": "sha512-wyv5KxmgG/Qivd0eUkQ4mpAdy3caPV9WrPd10MMw/0TGyCCrzq7+REZYVilRy1+VWQspQxWxRH7Kex9+LqPlKA==",
+      "version": "8.2.23",
+      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.2.23.tgz",
+      "integrity": "sha512-5idaKH7z0HKRAlfGH4BjqSlRKQh4yzVd5BWJ0MCPL20Rn6jmaIJSdjMHTrIfVhzLvSxn+7MQRV9a8S+AvIDUHQ==",
       "requires": {
-        "@fluentui/merge-styles": "^8.5.3",
-        "@fluentui/set-version": "^8.2.2",
-        "@fluentui/style-utilities": "^8.8.1",
-        "@fluentui/utilities": "^8.13.2",
+        "@fluentui/merge-styles": "^8.5.4",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/utilities": "^8.13.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/dom-utilities": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.3.tgz",
+          "integrity": "sha512-Ml/xwpTC6vb9lHHVAbSUD9jMbt9nVzV208D0FEoQn0c0+dP2vdMXSvXC/QHs/57B6JicttVQPuX6EcPwR3Mkpg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/merge-styles": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.4.tgz",
+          "integrity": "sha512-CeQIEcEgZu0cxqqyhJyTqySXoUL1vXfdWDJ8WMzchaNnhvOvoXISw8xXHpNXUtEn+HgPrcy9mHQwFcAc+jv3Wg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/style-utilities": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.2.tgz",
+          "integrity": "sha512-tef1nyWmgQTbETmvjQewxLfeJ+sJ21i3VzwBpK5qvj8MLwCHkMSBoDL7gXp6xCN2VSrQc0TkbykgUvRyJ2IReg==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/theme": "^2.6.18",
+            "@fluentui/utilities": "^8.13.3",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/theme": {
+          "version": "2.6.18",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.18.tgz",
+          "integrity": "sha512-NWiKCX62XDZ8FYjCN0Km4soFfqSyxqoTtxRVBVC5rujbkMbWyzyV/WpGz5ZNcrudhg/5LWNwILhyXxLRalG3mQ==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/utilities": {
+          "version": "8.13.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.3.tgz",
+          "integrity": "sha512-Nshe8pWKO/KngRx32EdhW5hvi5ZUWDR6hZcAGNgfLmXXQh3ZrTqAuLtmntv5PHvgbwz1qIsHfvqHgfAcHtoSpw==",
+          "requires": {
+            "@fluentui/dom-utilities": "^2.2.3",
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
     "@fluentui/keyboard-key": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.4.2.tgz",
-      "integrity": "sha512-6WdMrnFpY94uWefUGGRqO4WiS6R+Kso6/FR95SxXMuS6kfnjGJCHzywFGZcN5OU1fX067Zna4aPQ/nDwYMgBPw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.4.3.tgz",
+      "integrity": "sha512-uLiwx+UyXDN7tShv/s2NzDPtqeT/BZCHvY9yxEeb6LgEkos8TZvT5ep/7G8BpxA/SuBnviZ8xpDB5JObyZikqQ==",
       "requires": {
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -1817,29 +1967,111 @@
       }
     },
     "@fluentui/react": {
-      "version": "8.17.4",
-      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.17.4.tgz",
-      "integrity": "sha512-9H9kNL8p/hpVIXk0SPh7ExhX00HuBofbbeU6rnBqWbKfOdbV+iQ8INsvZWAE1JcWoaxP3iscZcM3N0ViH218HA==",
+      "version": "8.101.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.101.0.tgz",
+      "integrity": "sha512-kIVujMFy/vszhCO4GwxMhEIcQ9NCWm2GOqXjX0X/iLzR6g0yOUwzIfdTcKJrD8zpg1g41pANeYdpAnWrl/se6g==",
       "requires": {
-        "@fluentui/date-time-utilities": "^8.1.2",
-        "@fluentui/font-icons-mdl2": "^8.1.2",
-        "@fluentui/foundation-legacy": "^8.1.2",
-        "@fluentui/merge-styles": "^8.1.2",
-        "@fluentui/react-focus": "^8.1.3",
-        "@fluentui/react-hooks": "^8.2.2",
-        "@fluentui/react-window-provider": "^2.1.2",
-        "@fluentui/set-version": "^8.1.2",
-        "@fluentui/style-utilities": "^8.1.2",
-        "@fluentui/theme": "^2.1.2",
-        "@fluentui/utilities": "^8.1.2",
+        "@fluentui/date-time-utilities": "^8.5.3",
+        "@fluentui/font-icons-mdl2": "^8.5.3",
+        "@fluentui/foundation-legacy": "^8.2.23",
+        "@fluentui/merge-styles": "^8.5.4",
+        "@fluentui/react-focus": "^8.8.9",
+        "@fluentui/react-hooks": "^8.6.13",
+        "@fluentui/react-portal-compat-context": "^9.0.3",
+        "@fluentui/react-window-provider": "^2.2.4",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/theme": "^2.6.18",
+        "@fluentui/utilities": "^8.13.3",
         "@microsoft/load-themed-styles": "^1.10.26",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/dom-utilities": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.3.tgz",
+          "integrity": "sha512-Ml/xwpTC6vb9lHHVAbSUD9jMbt9nVzV208D0FEoQn0c0+dP2vdMXSvXC/QHs/57B6JicttVQPuX6EcPwR3Mkpg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/merge-styles": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.4.tgz",
+          "integrity": "sha512-CeQIEcEgZu0cxqqyhJyTqySXoUL1vXfdWDJ8WMzchaNnhvOvoXISw8xXHpNXUtEn+HgPrcy9mHQwFcAc+jv3Wg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/react-hooks": {
+          "version": "8.6.13",
+          "resolved": "https://registry.npmjs.org/@fluentui/react-hooks/-/react-hooks-8.6.13.tgz",
+          "integrity": "sha512-RAbVuwzX40czyNNkVpRFYKST2dX+PL0qIT5LB92SWqhEfyZjMOcOeg/YaEoLFZKNOVilAfUItSCD6HzurO4aLA==",
+          "requires": {
+            "@fluentui/react-window-provider": "^2.2.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/react-window-provider": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-2.2.4.tgz",
+          "integrity": "sha512-tCiIGQSILSipcn8DwwRgYq5IMtwBKiSQ+/cVRNq54cJZoq5ie/kMGFpldZ+vREDbM8wjmO3eNgNi63A3QRx39g==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/style-utilities": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.2.tgz",
+          "integrity": "sha512-tef1nyWmgQTbETmvjQewxLfeJ+sJ21i3VzwBpK5qvj8MLwCHkMSBoDL7gXp6xCN2VSrQc0TkbykgUvRyJ2IReg==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/theme": "^2.6.18",
+            "@fluentui/utilities": "^8.13.3",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/theme": {
+          "version": "2.6.18",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.18.tgz",
+          "integrity": "sha512-NWiKCX62XDZ8FYjCN0Km4soFfqSyxqoTtxRVBVC5rujbkMbWyzyV/WpGz5ZNcrudhg/5LWNwILhyXxLRalG3mQ==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/utilities": {
+          "version": "8.13.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.3.tgz",
+          "integrity": "sha512-Nshe8pWKO/KngRx32EdhW5hvi5ZUWDR6hZcAGNgfLmXXQh3ZrTqAuLtmntv5PHvgbwz1qIsHfvqHgfAcHtoSpw==",
+          "requires": {
+            "@fluentui/dom-utilities": "^2.2.3",
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -1907,22 +2139,83 @@
       }
     },
     "@fluentui/react-focus": {
-      "version": "8.8.8",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.8.8.tgz",
-      "integrity": "sha512-N4JmmduWk50tIGTH6kYTDa1HJfJ9qzGztbmo7HEh+gzHLwHDkL0GOV5+VWfwPuBcUqD1eKP4fz/e/gCBswBShg==",
+      "version": "8.8.9",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.8.9.tgz",
+      "integrity": "sha512-lYixFOZ2OjULcWhD3MppxzAt6aImkhNQiNtUJzswBV1xmYvkpYOxXK2hxf3/CeRAFijcmuAIvwg1rRgYBfRxxA==",
       "requires": {
-        "@fluentui/keyboard-key": "^0.4.2",
-        "@fluentui/merge-styles": "^8.5.3",
-        "@fluentui/set-version": "^8.2.2",
-        "@fluentui/style-utilities": "^8.8.1",
-        "@fluentui/utilities": "^8.13.2",
+        "@fluentui/keyboard-key": "^0.4.3",
+        "@fluentui/merge-styles": "^8.5.4",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/utilities": "^8.13.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/dom-utilities": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.3.tgz",
+          "integrity": "sha512-Ml/xwpTC6vb9lHHVAbSUD9jMbt9nVzV208D0FEoQn0c0+dP2vdMXSvXC/QHs/57B6JicttVQPuX6EcPwR3Mkpg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/merge-styles": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.4.tgz",
+          "integrity": "sha512-CeQIEcEgZu0cxqqyhJyTqySXoUL1vXfdWDJ8WMzchaNnhvOvoXISw8xXHpNXUtEn+HgPrcy9mHQwFcAc+jv3Wg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/style-utilities": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.2.tgz",
+          "integrity": "sha512-tef1nyWmgQTbETmvjQewxLfeJ+sJ21i3VzwBpK5qvj8MLwCHkMSBoDL7gXp6xCN2VSrQc0TkbykgUvRyJ2IReg==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/theme": "^2.6.18",
+            "@fluentui/utilities": "^8.13.3",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/theme": {
+          "version": "2.6.18",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.18.tgz",
+          "integrity": "sha512-NWiKCX62XDZ8FYjCN0Km4soFfqSyxqoTtxRVBVC5rujbkMbWyzyV/WpGz5ZNcrudhg/5LWNwILhyXxLRalG3mQ==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/utilities": {
+          "version": "8.13.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.3.tgz",
+          "integrity": "sha512-Nshe8pWKO/KngRx32EdhW5hvi5ZUWDR6hZcAGNgfLmXXQh3ZrTqAuLtmntv5PHvgbwz1qIsHfvqHgfAcHtoSpw==",
+          "requires": {
+            "@fluentui/dom-utilities": "^2.2.3",
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -2029,6 +2322,21 @@
       "requires": {
         "@babel/runtime": "^7.10.4",
         "@fluentui/styles": "^0.61.0"
+      }
+    },
+    "@fluentui/react-portal-compat-context": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-portal-compat-context/-/react-portal-compat-context-9.0.3.tgz",
+      "integrity": "sha512-XZczqvKJflK6jFv6RekFXzZFnxvd1tBbIsRFs6JMX8zNqMO7ZQJ6Yfee5LLs6HnZE5BKowE7jIUMOTH9yOmyJg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@fluentui/react-proptypes": {

--- a/ui-library-quickstart-ui-components/package.json
+++ b/ui-library-quickstart-ui-components/package.json
@@ -6,6 +6,7 @@
     "@azure/communication-calling": "1.4.4",
     "@azure/communication-chat": "1.2.0",
     "@azure/communication-react": "1.3.1",
+    "@fluentui/react": "8.101.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",

--- a/ui-library-quickstart-ui-components/src/App.tsx
+++ b/ui-library-quickstart-ui-components/src/App.tsx
@@ -1,9 +1,8 @@
 import { FluentThemeProvider } from '@azure/communication-react';
-import { Stack } from '@fluentui/react';
+import { initializeIcons, registerIcons, Stack } from '@fluentui/react';
 import React from 'react';
 import { CallingComponents } from './CallingComponents';
 import { ChatComponents } from './ChatComponents';
-import { registerIcons } from '@fluentui/react';
 import {
   DEFAULT_COMPONENT_ICONS
 } from '@azure/communication-react';
@@ -15,6 +14,7 @@ function CompletedComponentsApp(): JSX.Element {
     }
   };
 
+  initializeIcons();
   registerIcons({ icons: DEFAULT_COMPONENT_ICONS });
 
   return (

--- a/ui-library-starting-with-calling-stateful/package-lock.json
+++ b/ui-library-starting-with-calling-stateful/package-lock.json
@@ -178,6 +178,26 @@
             "@azure/core-asynciterator-polyfill": "^1.0.0"
           }
         },
+        "@fluentui/react": {
+          "version": "8.17.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.17.4.tgz",
+          "integrity": "sha512-9H9kNL8p/hpVIXk0SPh7ExhX00HuBofbbeU6rnBqWbKfOdbV+iQ8INsvZWAE1JcWoaxP3iscZcM3N0ViH218HA==",
+          "requires": {
+            "@fluentui/date-time-utilities": "^8.1.2",
+            "@fluentui/font-icons-mdl2": "^8.1.2",
+            "@fluentui/foundation-legacy": "^8.1.2",
+            "@fluentui/merge-styles": "^8.1.2",
+            "@fluentui/react-focus": "^8.1.3",
+            "@fluentui/react-hooks": "^8.2.2",
+            "@fluentui/react-window-provider": "^2.1.2",
+            "@fluentui/set-version": "^8.1.2",
+            "@fluentui/style-utilities": "^8.1.2",
+            "@fluentui/theme": "^2.1.2",
+            "@fluentui/utilities": "^8.1.2",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
         "@opentelemetry/api": {
           "version": "1.0.0-rc.0",
           "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.0-rc.0.tgz",
@@ -1699,18 +1719,26 @@
       }
     },
     "@fluentui/date-time-utilities": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.5.2.tgz",
-      "integrity": "sha512-u540ACUdnC+Jms1DIHkho80eJmoCg/LtAzR4a/1Tum6PicxWv59UYp9Ba7qFbIw+mrjWnwX/2ZmBpqTy9Rgn7w==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.5.3.tgz",
+      "integrity": "sha512-jwbwcJlnerdjENIAfn/YHxl5H2sQruReOMWXWMgmvX0CmcbqsN9VBxBt+E35Tlr4Ds3MbGs60eyfZUIPpaB5RQ==",
       "requires": {
-        "@fluentui/set-version": "^8.2.2",
+        "@fluentui/set-version": "^8.2.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -1731,54 +1759,176 @@
       }
     },
     "@fluentui/font-icons-mdl2": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.5.2.tgz",
-      "integrity": "sha512-qDbZNiXVPx6X/Z2MpU3Oa2kWNSrk5+mG8ZRdH/thD7iwnV4l6DtBctNyXK/Cjq4EpG3eQQra8LBVxwOyDt0GqA==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.5.3.tgz",
+      "integrity": "sha512-C1P2fvaj8kka4tLJOoZPopq4kz2ZNCZ4ImGVvek8t7DOayOU2UoTKNoVKhNjynagbsLpwpOYA8Uzb4Ialx+/uQ==",
       "requires": {
-        "@fluentui/set-version": "^8.2.2",
-        "@fluentui/style-utilities": "^8.8.1",
-        "@fluentui/utilities": "^8.13.2",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/utilities": "^8.13.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/dom-utilities": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.3.tgz",
+          "integrity": "sha512-Ml/xwpTC6vb9lHHVAbSUD9jMbt9nVzV208D0FEoQn0c0+dP2vdMXSvXC/QHs/57B6JicttVQPuX6EcPwR3Mkpg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/merge-styles": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.4.tgz",
+          "integrity": "sha512-CeQIEcEgZu0cxqqyhJyTqySXoUL1vXfdWDJ8WMzchaNnhvOvoXISw8xXHpNXUtEn+HgPrcy9mHQwFcAc+jv3Wg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/style-utilities": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.2.tgz",
+          "integrity": "sha512-tef1nyWmgQTbETmvjQewxLfeJ+sJ21i3VzwBpK5qvj8MLwCHkMSBoDL7gXp6xCN2VSrQc0TkbykgUvRyJ2IReg==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/theme": "^2.6.18",
+            "@fluentui/utilities": "^8.13.3",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/theme": {
+          "version": "2.6.18",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.18.tgz",
+          "integrity": "sha512-NWiKCX62XDZ8FYjCN0Km4soFfqSyxqoTtxRVBVC5rujbkMbWyzyV/WpGz5ZNcrudhg/5LWNwILhyXxLRalG3mQ==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/utilities": {
+          "version": "8.13.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.3.tgz",
+          "integrity": "sha512-Nshe8pWKO/KngRx32EdhW5hvi5ZUWDR6hZcAGNgfLmXXQh3ZrTqAuLtmntv5PHvgbwz1qIsHfvqHgfAcHtoSpw==",
+          "requires": {
+            "@fluentui/dom-utilities": "^2.2.3",
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
     "@fluentui/foundation-legacy": {
-      "version": "8.2.22",
-      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.2.22.tgz",
-      "integrity": "sha512-wyv5KxmgG/Qivd0eUkQ4mpAdy3caPV9WrPd10MMw/0TGyCCrzq7+REZYVilRy1+VWQspQxWxRH7Kex9+LqPlKA==",
+      "version": "8.2.23",
+      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.2.23.tgz",
+      "integrity": "sha512-5idaKH7z0HKRAlfGH4BjqSlRKQh4yzVd5BWJ0MCPL20Rn6jmaIJSdjMHTrIfVhzLvSxn+7MQRV9a8S+AvIDUHQ==",
       "requires": {
-        "@fluentui/merge-styles": "^8.5.3",
-        "@fluentui/set-version": "^8.2.2",
-        "@fluentui/style-utilities": "^8.8.1",
-        "@fluentui/utilities": "^8.13.2",
+        "@fluentui/merge-styles": "^8.5.4",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/utilities": "^8.13.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/dom-utilities": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.3.tgz",
+          "integrity": "sha512-Ml/xwpTC6vb9lHHVAbSUD9jMbt9nVzV208D0FEoQn0c0+dP2vdMXSvXC/QHs/57B6JicttVQPuX6EcPwR3Mkpg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/merge-styles": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.4.tgz",
+          "integrity": "sha512-CeQIEcEgZu0cxqqyhJyTqySXoUL1vXfdWDJ8WMzchaNnhvOvoXISw8xXHpNXUtEn+HgPrcy9mHQwFcAc+jv3Wg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/style-utilities": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.2.tgz",
+          "integrity": "sha512-tef1nyWmgQTbETmvjQewxLfeJ+sJ21i3VzwBpK5qvj8MLwCHkMSBoDL7gXp6xCN2VSrQc0TkbykgUvRyJ2IReg==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/theme": "^2.6.18",
+            "@fluentui/utilities": "^8.13.3",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/theme": {
+          "version": "2.6.18",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.18.tgz",
+          "integrity": "sha512-NWiKCX62XDZ8FYjCN0Km4soFfqSyxqoTtxRVBVC5rujbkMbWyzyV/WpGz5ZNcrudhg/5LWNwILhyXxLRalG3mQ==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/utilities": {
+          "version": "8.13.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.3.tgz",
+          "integrity": "sha512-Nshe8pWKO/KngRx32EdhW5hvi5ZUWDR6hZcAGNgfLmXXQh3ZrTqAuLtmntv5PHvgbwz1qIsHfvqHgfAcHtoSpw==",
+          "requires": {
+            "@fluentui/dom-utilities": "^2.2.3",
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
     "@fluentui/keyboard-key": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.4.2.tgz",
-      "integrity": "sha512-6WdMrnFpY94uWefUGGRqO4WiS6R+Kso6/FR95SxXMuS6kfnjGJCHzywFGZcN5OU1fX067Zna4aPQ/nDwYMgBPw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.4.3.tgz",
+      "integrity": "sha512-uLiwx+UyXDN7tShv/s2NzDPtqeT/BZCHvY9yxEeb6LgEkos8TZvT5ep/7G8BpxA/SuBnviZ8xpDB5JObyZikqQ==",
       "requires": {
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -1799,29 +1949,111 @@
       }
     },
     "@fluentui/react": {
-      "version": "8.17.4",
-      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.17.4.tgz",
-      "integrity": "sha512-9H9kNL8p/hpVIXk0SPh7ExhX00HuBofbbeU6rnBqWbKfOdbV+iQ8INsvZWAE1JcWoaxP3iscZcM3N0ViH218HA==",
+      "version": "8.101.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.101.0.tgz",
+      "integrity": "sha512-kIVujMFy/vszhCO4GwxMhEIcQ9NCWm2GOqXjX0X/iLzR6g0yOUwzIfdTcKJrD8zpg1g41pANeYdpAnWrl/se6g==",
       "requires": {
-        "@fluentui/date-time-utilities": "^8.1.2",
-        "@fluentui/font-icons-mdl2": "^8.1.2",
-        "@fluentui/foundation-legacy": "^8.1.2",
-        "@fluentui/merge-styles": "^8.1.2",
-        "@fluentui/react-focus": "^8.1.3",
-        "@fluentui/react-hooks": "^8.2.2",
-        "@fluentui/react-window-provider": "^2.1.2",
-        "@fluentui/set-version": "^8.1.2",
-        "@fluentui/style-utilities": "^8.1.2",
-        "@fluentui/theme": "^2.1.2",
-        "@fluentui/utilities": "^8.1.2",
+        "@fluentui/date-time-utilities": "^8.5.3",
+        "@fluentui/font-icons-mdl2": "^8.5.3",
+        "@fluentui/foundation-legacy": "^8.2.23",
+        "@fluentui/merge-styles": "^8.5.4",
+        "@fluentui/react-focus": "^8.8.9",
+        "@fluentui/react-hooks": "^8.6.13",
+        "@fluentui/react-portal-compat-context": "^9.0.3",
+        "@fluentui/react-window-provider": "^2.2.4",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/theme": "^2.6.18",
+        "@fluentui/utilities": "^8.13.3",
         "@microsoft/load-themed-styles": "^1.10.26",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/dom-utilities": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.3.tgz",
+          "integrity": "sha512-Ml/xwpTC6vb9lHHVAbSUD9jMbt9nVzV208D0FEoQn0c0+dP2vdMXSvXC/QHs/57B6JicttVQPuX6EcPwR3Mkpg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/merge-styles": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.4.tgz",
+          "integrity": "sha512-CeQIEcEgZu0cxqqyhJyTqySXoUL1vXfdWDJ8WMzchaNnhvOvoXISw8xXHpNXUtEn+HgPrcy9mHQwFcAc+jv3Wg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/react-hooks": {
+          "version": "8.6.13",
+          "resolved": "https://registry.npmjs.org/@fluentui/react-hooks/-/react-hooks-8.6.13.tgz",
+          "integrity": "sha512-RAbVuwzX40czyNNkVpRFYKST2dX+PL0qIT5LB92SWqhEfyZjMOcOeg/YaEoLFZKNOVilAfUItSCD6HzurO4aLA==",
+          "requires": {
+            "@fluentui/react-window-provider": "^2.2.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/react-window-provider": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-2.2.4.tgz",
+          "integrity": "sha512-tCiIGQSILSipcn8DwwRgYq5IMtwBKiSQ+/cVRNq54cJZoq5ie/kMGFpldZ+vREDbM8wjmO3eNgNi63A3QRx39g==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/style-utilities": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.2.tgz",
+          "integrity": "sha512-tef1nyWmgQTbETmvjQewxLfeJ+sJ21i3VzwBpK5qvj8MLwCHkMSBoDL7gXp6xCN2VSrQc0TkbykgUvRyJ2IReg==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/theme": "^2.6.18",
+            "@fluentui/utilities": "^8.13.3",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/theme": {
+          "version": "2.6.18",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.18.tgz",
+          "integrity": "sha512-NWiKCX62XDZ8FYjCN0Km4soFfqSyxqoTtxRVBVC5rujbkMbWyzyV/WpGz5ZNcrudhg/5LWNwILhyXxLRalG3mQ==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/utilities": {
+          "version": "8.13.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.3.tgz",
+          "integrity": "sha512-Nshe8pWKO/KngRx32EdhW5hvi5ZUWDR6hZcAGNgfLmXXQh3ZrTqAuLtmntv5PHvgbwz1qIsHfvqHgfAcHtoSpw==",
+          "requires": {
+            "@fluentui/dom-utilities": "^2.2.3",
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -1889,22 +2121,83 @@
       }
     },
     "@fluentui/react-focus": {
-      "version": "8.8.8",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.8.8.tgz",
-      "integrity": "sha512-N4JmmduWk50tIGTH6kYTDa1HJfJ9qzGztbmo7HEh+gzHLwHDkL0GOV5+VWfwPuBcUqD1eKP4fz/e/gCBswBShg==",
+      "version": "8.8.9",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.8.9.tgz",
+      "integrity": "sha512-lYixFOZ2OjULcWhD3MppxzAt6aImkhNQiNtUJzswBV1xmYvkpYOxXK2hxf3/CeRAFijcmuAIvwg1rRgYBfRxxA==",
       "requires": {
-        "@fluentui/keyboard-key": "^0.4.2",
-        "@fluentui/merge-styles": "^8.5.3",
-        "@fluentui/set-version": "^8.2.2",
-        "@fluentui/style-utilities": "^8.8.1",
-        "@fluentui/utilities": "^8.13.2",
+        "@fluentui/keyboard-key": "^0.4.3",
+        "@fluentui/merge-styles": "^8.5.4",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/utilities": "^8.13.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/dom-utilities": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.3.tgz",
+          "integrity": "sha512-Ml/xwpTC6vb9lHHVAbSUD9jMbt9nVzV208D0FEoQn0c0+dP2vdMXSvXC/QHs/57B6JicttVQPuX6EcPwR3Mkpg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/merge-styles": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.4.tgz",
+          "integrity": "sha512-CeQIEcEgZu0cxqqyhJyTqySXoUL1vXfdWDJ8WMzchaNnhvOvoXISw8xXHpNXUtEn+HgPrcy9mHQwFcAc+jv3Wg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/style-utilities": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.2.tgz",
+          "integrity": "sha512-tef1nyWmgQTbETmvjQewxLfeJ+sJ21i3VzwBpK5qvj8MLwCHkMSBoDL7gXp6xCN2VSrQc0TkbykgUvRyJ2IReg==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/theme": "^2.6.18",
+            "@fluentui/utilities": "^8.13.3",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/theme": {
+          "version": "2.6.18",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.18.tgz",
+          "integrity": "sha512-NWiKCX62XDZ8FYjCN0Km4soFfqSyxqoTtxRVBVC5rujbkMbWyzyV/WpGz5ZNcrudhg/5LWNwILhyXxLRalG3mQ==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/utilities": {
+          "version": "8.13.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.3.tgz",
+          "integrity": "sha512-Nshe8pWKO/KngRx32EdhW5hvi5ZUWDR6hZcAGNgfLmXXQh3ZrTqAuLtmntv5PHvgbwz1qIsHfvqHgfAcHtoSpw==",
+          "requires": {
+            "@fluentui/dom-utilities": "^2.2.3",
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -2011,6 +2304,21 @@
       "requires": {
         "@babel/runtime": "^7.10.4",
         "@fluentui/styles": "^0.61.0"
+      }
+    },
+    "@fluentui/react-portal-compat-context": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-portal-compat-context/-/react-portal-compat-context-9.0.3.tgz",
+      "integrity": "sha512-XZczqvKJflK6jFv6RekFXzZFnxvd1tBbIsRFs6JMX8zNqMO7ZQJ6Yfee5LLs6HnZE5BKowE7jIUMOTH9yOmyJg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@fluentui/react-proptypes": {

--- a/ui-library-starting-with-calling-stateful/package.json
+++ b/ui-library-starting-with-calling-stateful/package.json
@@ -6,6 +6,7 @@
     "@azure/communication-calling": "1.4.4",
     "@azure/communication-chat": "1.2.0",
     "@azure/communication-react": "1.3.1",
+    "@fluentui/react": "8.101.0",
     "@testing-library/jest-dom": "^5.15.0",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",

--- a/ui-library-starting-with-calling-stateful/src/App.tsx
+++ b/ui-library-starting-with-calling-stateful/src/App.tsx
@@ -10,16 +10,18 @@ import {
 } from '@azure/communication-react';
 import React, { useEffect, useState } from 'react';
 import CallingComponents from './CallingComponentsStateful';
-import { registerIcons } from '@fluentui/react';
+import { initializeIcons, registerIcons } from '@fluentui/react';
 import { Call, CallAgent } from '@azure/communication-calling';
+
+
+initializeIcons();
+registerIcons({ icons: DEFAULT_COMPONENT_ICONS });
 
 function App(): JSX.Element {
   const userAccessToken = '<Azure Communication Services Resource Access Token>';
   const userId = '<User Id associated to the token>';
   const groupId = '<Generated GUID groupd id>';
   const displayName = '<Display Name>';
-
-  registerIcons({ icons: DEFAULT_COMPONENT_ICONS });
 
   const [statefulCallClient, setStatefulCallClient] = useState<StatefulCallClient>();
   const [callAgent, setCallAgent] = useState<CallAgent>();

--- a/ui-library-starting-with-chat-stateful/package-lock.json
+++ b/ui-library-starting-with-chat-stateful/package-lock.json
@@ -178,6 +178,26 @@
             "@azure/core-asynciterator-polyfill": "^1.0.0"
           }
         },
+        "@fluentui/react": {
+          "version": "8.17.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.17.4.tgz",
+          "integrity": "sha512-9H9kNL8p/hpVIXk0SPh7ExhX00HuBofbbeU6rnBqWbKfOdbV+iQ8INsvZWAE1JcWoaxP3iscZcM3N0ViH218HA==",
+          "requires": {
+            "@fluentui/date-time-utilities": "^8.1.2",
+            "@fluentui/font-icons-mdl2": "^8.1.2",
+            "@fluentui/foundation-legacy": "^8.1.2",
+            "@fluentui/merge-styles": "^8.1.2",
+            "@fluentui/react-focus": "^8.1.3",
+            "@fluentui/react-hooks": "^8.2.2",
+            "@fluentui/react-window-provider": "^2.1.2",
+            "@fluentui/set-version": "^8.1.2",
+            "@fluentui/style-utilities": "^8.1.2",
+            "@fluentui/theme": "^2.1.2",
+            "@fluentui/utilities": "^8.1.2",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
         "@opentelemetry/api": {
           "version": "1.0.0-rc.0",
           "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.0-rc.0.tgz",
@@ -1726,18 +1746,26 @@
       }
     },
     "@fluentui/date-time-utilities": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.5.2.tgz",
-      "integrity": "sha512-u540ACUdnC+Jms1DIHkho80eJmoCg/LtAzR4a/1Tum6PicxWv59UYp9Ba7qFbIw+mrjWnwX/2ZmBpqTy9Rgn7w==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.5.3.tgz",
+      "integrity": "sha512-jwbwcJlnerdjENIAfn/YHxl5H2sQruReOMWXWMgmvX0CmcbqsN9VBxBt+E35Tlr4Ds3MbGs60eyfZUIPpaB5RQ==",
       "requires": {
-        "@fluentui/set-version": "^8.2.2",
+        "@fluentui/set-version": "^8.2.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -1758,54 +1786,176 @@
       }
     },
     "@fluentui/font-icons-mdl2": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.5.2.tgz",
-      "integrity": "sha512-qDbZNiXVPx6X/Z2MpU3Oa2kWNSrk5+mG8ZRdH/thD7iwnV4l6DtBctNyXK/Cjq4EpG3eQQra8LBVxwOyDt0GqA==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.5.3.tgz",
+      "integrity": "sha512-C1P2fvaj8kka4tLJOoZPopq4kz2ZNCZ4ImGVvek8t7DOayOU2UoTKNoVKhNjynagbsLpwpOYA8Uzb4Ialx+/uQ==",
       "requires": {
-        "@fluentui/set-version": "^8.2.2",
-        "@fluentui/style-utilities": "^8.8.1",
-        "@fluentui/utilities": "^8.13.2",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/utilities": "^8.13.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/dom-utilities": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.3.tgz",
+          "integrity": "sha512-Ml/xwpTC6vb9lHHVAbSUD9jMbt9nVzV208D0FEoQn0c0+dP2vdMXSvXC/QHs/57B6JicttVQPuX6EcPwR3Mkpg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/merge-styles": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.4.tgz",
+          "integrity": "sha512-CeQIEcEgZu0cxqqyhJyTqySXoUL1vXfdWDJ8WMzchaNnhvOvoXISw8xXHpNXUtEn+HgPrcy9mHQwFcAc+jv3Wg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/style-utilities": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.2.tgz",
+          "integrity": "sha512-tef1nyWmgQTbETmvjQewxLfeJ+sJ21i3VzwBpK5qvj8MLwCHkMSBoDL7gXp6xCN2VSrQc0TkbykgUvRyJ2IReg==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/theme": "^2.6.18",
+            "@fluentui/utilities": "^8.13.3",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/theme": {
+          "version": "2.6.18",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.18.tgz",
+          "integrity": "sha512-NWiKCX62XDZ8FYjCN0Km4soFfqSyxqoTtxRVBVC5rujbkMbWyzyV/WpGz5ZNcrudhg/5LWNwILhyXxLRalG3mQ==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/utilities": {
+          "version": "8.13.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.3.tgz",
+          "integrity": "sha512-Nshe8pWKO/KngRx32EdhW5hvi5ZUWDR6hZcAGNgfLmXXQh3ZrTqAuLtmntv5PHvgbwz1qIsHfvqHgfAcHtoSpw==",
+          "requires": {
+            "@fluentui/dom-utilities": "^2.2.3",
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
     "@fluentui/foundation-legacy": {
-      "version": "8.2.22",
-      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.2.22.tgz",
-      "integrity": "sha512-wyv5KxmgG/Qivd0eUkQ4mpAdy3caPV9WrPd10MMw/0TGyCCrzq7+REZYVilRy1+VWQspQxWxRH7Kex9+LqPlKA==",
+      "version": "8.2.23",
+      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.2.23.tgz",
+      "integrity": "sha512-5idaKH7z0HKRAlfGH4BjqSlRKQh4yzVd5BWJ0MCPL20Rn6jmaIJSdjMHTrIfVhzLvSxn+7MQRV9a8S+AvIDUHQ==",
       "requires": {
-        "@fluentui/merge-styles": "^8.5.3",
-        "@fluentui/set-version": "^8.2.2",
-        "@fluentui/style-utilities": "^8.8.1",
-        "@fluentui/utilities": "^8.13.2",
+        "@fluentui/merge-styles": "^8.5.4",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/utilities": "^8.13.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/dom-utilities": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.3.tgz",
+          "integrity": "sha512-Ml/xwpTC6vb9lHHVAbSUD9jMbt9nVzV208D0FEoQn0c0+dP2vdMXSvXC/QHs/57B6JicttVQPuX6EcPwR3Mkpg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/merge-styles": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.4.tgz",
+          "integrity": "sha512-CeQIEcEgZu0cxqqyhJyTqySXoUL1vXfdWDJ8WMzchaNnhvOvoXISw8xXHpNXUtEn+HgPrcy9mHQwFcAc+jv3Wg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/style-utilities": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.2.tgz",
+          "integrity": "sha512-tef1nyWmgQTbETmvjQewxLfeJ+sJ21i3VzwBpK5qvj8MLwCHkMSBoDL7gXp6xCN2VSrQc0TkbykgUvRyJ2IReg==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/theme": "^2.6.18",
+            "@fluentui/utilities": "^8.13.3",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/theme": {
+          "version": "2.6.18",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.18.tgz",
+          "integrity": "sha512-NWiKCX62XDZ8FYjCN0Km4soFfqSyxqoTtxRVBVC5rujbkMbWyzyV/WpGz5ZNcrudhg/5LWNwILhyXxLRalG3mQ==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/utilities": {
+          "version": "8.13.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.3.tgz",
+          "integrity": "sha512-Nshe8pWKO/KngRx32EdhW5hvi5ZUWDR6hZcAGNgfLmXXQh3ZrTqAuLtmntv5PHvgbwz1qIsHfvqHgfAcHtoSpw==",
+          "requires": {
+            "@fluentui/dom-utilities": "^2.2.3",
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
     "@fluentui/keyboard-key": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.4.2.tgz",
-      "integrity": "sha512-6WdMrnFpY94uWefUGGRqO4WiS6R+Kso6/FR95SxXMuS6kfnjGJCHzywFGZcN5OU1fX067Zna4aPQ/nDwYMgBPw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.4.3.tgz",
+      "integrity": "sha512-uLiwx+UyXDN7tShv/s2NzDPtqeT/BZCHvY9yxEeb6LgEkos8TZvT5ep/7G8BpxA/SuBnviZ8xpDB5JObyZikqQ==",
       "requires": {
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -1826,29 +1976,111 @@
       }
     },
     "@fluentui/react": {
-      "version": "8.17.4",
-      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.17.4.tgz",
-      "integrity": "sha512-9H9kNL8p/hpVIXk0SPh7ExhX00HuBofbbeU6rnBqWbKfOdbV+iQ8INsvZWAE1JcWoaxP3iscZcM3N0ViH218HA==",
+      "version": "8.101.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.101.0.tgz",
+      "integrity": "sha512-kIVujMFy/vszhCO4GwxMhEIcQ9NCWm2GOqXjX0X/iLzR6g0yOUwzIfdTcKJrD8zpg1g41pANeYdpAnWrl/se6g==",
       "requires": {
-        "@fluentui/date-time-utilities": "^8.1.2",
-        "@fluentui/font-icons-mdl2": "^8.1.2",
-        "@fluentui/foundation-legacy": "^8.1.2",
-        "@fluentui/merge-styles": "^8.1.2",
-        "@fluentui/react-focus": "^8.1.3",
-        "@fluentui/react-hooks": "^8.2.2",
-        "@fluentui/react-window-provider": "^2.1.2",
-        "@fluentui/set-version": "^8.1.2",
-        "@fluentui/style-utilities": "^8.1.2",
-        "@fluentui/theme": "^2.1.2",
-        "@fluentui/utilities": "^8.1.2",
+        "@fluentui/date-time-utilities": "^8.5.3",
+        "@fluentui/font-icons-mdl2": "^8.5.3",
+        "@fluentui/foundation-legacy": "^8.2.23",
+        "@fluentui/merge-styles": "^8.5.4",
+        "@fluentui/react-focus": "^8.8.9",
+        "@fluentui/react-hooks": "^8.6.13",
+        "@fluentui/react-portal-compat-context": "^9.0.3",
+        "@fluentui/react-window-provider": "^2.2.4",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/theme": "^2.6.18",
+        "@fluentui/utilities": "^8.13.3",
         "@microsoft/load-themed-styles": "^1.10.26",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/dom-utilities": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.3.tgz",
+          "integrity": "sha512-Ml/xwpTC6vb9lHHVAbSUD9jMbt9nVzV208D0FEoQn0c0+dP2vdMXSvXC/QHs/57B6JicttVQPuX6EcPwR3Mkpg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/merge-styles": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.4.tgz",
+          "integrity": "sha512-CeQIEcEgZu0cxqqyhJyTqySXoUL1vXfdWDJ8WMzchaNnhvOvoXISw8xXHpNXUtEn+HgPrcy9mHQwFcAc+jv3Wg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/react-hooks": {
+          "version": "8.6.13",
+          "resolved": "https://registry.npmjs.org/@fluentui/react-hooks/-/react-hooks-8.6.13.tgz",
+          "integrity": "sha512-RAbVuwzX40czyNNkVpRFYKST2dX+PL0qIT5LB92SWqhEfyZjMOcOeg/YaEoLFZKNOVilAfUItSCD6HzurO4aLA==",
+          "requires": {
+            "@fluentui/react-window-provider": "^2.2.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/react-window-provider": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-2.2.4.tgz",
+          "integrity": "sha512-tCiIGQSILSipcn8DwwRgYq5IMtwBKiSQ+/cVRNq54cJZoq5ie/kMGFpldZ+vREDbM8wjmO3eNgNi63A3QRx39g==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/style-utilities": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.2.tgz",
+          "integrity": "sha512-tef1nyWmgQTbETmvjQewxLfeJ+sJ21i3VzwBpK5qvj8MLwCHkMSBoDL7gXp6xCN2VSrQc0TkbykgUvRyJ2IReg==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/theme": "^2.6.18",
+            "@fluentui/utilities": "^8.13.3",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/theme": {
+          "version": "2.6.18",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.18.tgz",
+          "integrity": "sha512-NWiKCX62XDZ8FYjCN0Km4soFfqSyxqoTtxRVBVC5rujbkMbWyzyV/WpGz5ZNcrudhg/5LWNwILhyXxLRalG3mQ==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/utilities": {
+          "version": "8.13.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.3.tgz",
+          "integrity": "sha512-Nshe8pWKO/KngRx32EdhW5hvi5ZUWDR6hZcAGNgfLmXXQh3ZrTqAuLtmntv5PHvgbwz1qIsHfvqHgfAcHtoSpw==",
+          "requires": {
+            "@fluentui/dom-utilities": "^2.2.3",
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -1916,22 +2148,83 @@
       }
     },
     "@fluentui/react-focus": {
-      "version": "8.8.8",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.8.8.tgz",
-      "integrity": "sha512-N4JmmduWk50tIGTH6kYTDa1HJfJ9qzGztbmo7HEh+gzHLwHDkL0GOV5+VWfwPuBcUqD1eKP4fz/e/gCBswBShg==",
+      "version": "8.8.9",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.8.9.tgz",
+      "integrity": "sha512-lYixFOZ2OjULcWhD3MppxzAt6aImkhNQiNtUJzswBV1xmYvkpYOxXK2hxf3/CeRAFijcmuAIvwg1rRgYBfRxxA==",
       "requires": {
-        "@fluentui/keyboard-key": "^0.4.2",
-        "@fluentui/merge-styles": "^8.5.3",
-        "@fluentui/set-version": "^8.2.2",
-        "@fluentui/style-utilities": "^8.8.1",
-        "@fluentui/utilities": "^8.13.2",
+        "@fluentui/keyboard-key": "^0.4.3",
+        "@fluentui/merge-styles": "^8.5.4",
+        "@fluentui/set-version": "^8.2.3",
+        "@fluentui/style-utilities": "^8.8.2",
+        "@fluentui/utilities": "^8.13.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@fluentui/dom-utilities": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.3.tgz",
+          "integrity": "sha512-Ml/xwpTC6vb9lHHVAbSUD9jMbt9nVzV208D0FEoQn0c0+dP2vdMXSvXC/QHs/57B6JicttVQPuX6EcPwR3Mkpg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/merge-styles": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.4.tgz",
+          "integrity": "sha512-CeQIEcEgZu0cxqqyhJyTqySXoUL1vXfdWDJ8WMzchaNnhvOvoXISw8xXHpNXUtEn+HgPrcy9mHQwFcAc+jv3Wg==",
+          "requires": {
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/set-version": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.3.tgz",
+          "integrity": "sha512-/+5vrI1Bq/ZsNDEK9++RClnDOeCILS8RXxZb7OAqmOc8GnPScxKcIN8e/1bosUxTjb2EB1KbVk6XeUpk0WvQIg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/style-utilities": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.8.2.tgz",
+          "integrity": "sha512-tef1nyWmgQTbETmvjQewxLfeJ+sJ21i3VzwBpK5qvj8MLwCHkMSBoDL7gXp6xCN2VSrQc0TkbykgUvRyJ2IReg==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/theme": "^2.6.18",
+            "@fluentui/utilities": "^8.13.3",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/theme": {
+          "version": "2.6.18",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.18.tgz",
+          "integrity": "sha512-NWiKCX62XDZ8FYjCN0Km4soFfqSyxqoTtxRVBVC5rujbkMbWyzyV/WpGz5ZNcrudhg/5LWNwILhyXxLRalG3mQ==",
+          "requires": {
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "@fluentui/utilities": "^8.13.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@fluentui/utilities": {
+          "version": "8.13.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.13.3.tgz",
+          "integrity": "sha512-Nshe8pWKO/KngRx32EdhW5hvi5ZUWDR6hZcAGNgfLmXXQh3ZrTqAuLtmntv5PHvgbwz1qIsHfvqHgfAcHtoSpw==",
+          "requires": {
+            "@fluentui/dom-utilities": "^2.2.3",
+            "@fluentui/merge-styles": "^8.5.4",
+            "@fluentui/set-version": "^8.2.3",
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -2038,6 +2331,21 @@
       "requires": {
         "@babel/runtime": "^7.10.4",
         "@fluentui/styles": "^0.61.0"
+      }
+    },
+    "@fluentui/react-portal-compat-context": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-portal-compat-context/-/react-portal-compat-context-9.0.3.tgz",
+      "integrity": "sha512-XZczqvKJflK6jFv6RekFXzZFnxvd1tBbIsRFs6JMX8zNqMO7ZQJ6Yfee5LLs6HnZE5BKowE7jIUMOTH9yOmyJg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@fluentui/react-proptypes": {

--- a/ui-library-starting-with-chat-stateful/package.json
+++ b/ui-library-starting-with-chat-stateful/package.json
@@ -6,6 +6,7 @@
     "@azure/communication-calling": "1.4.4",
     "@azure/communication-chat": "1.2.0",
     "@azure/communication-react": "1.3.1",
+    "@fluentui/react": "8.101.0",
     "@testing-library/jest-dom": "^5.15.0",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",

--- a/ui-library-starting-with-chat-stateful/src/App.tsx
+++ b/ui-library-starting-with-chat-stateful/src/App.tsx
@@ -8,7 +8,10 @@ import {
 } from '@azure/communication-react';
 import React from 'react';
 import ChatComponents from './ChatComponentsStateful';
-import { registerIcons } from '@fluentui/react';
+import { initializeIcons, registerIcons } from '@fluentui/react';
+
+initializeIcons();
+registerIcons({ icons: DEFAULT_COMPONENT_ICONS });
 
 function App(): JSX.Element {
   const endpointUrl = '<Azure Communication Services Resource Endpoint>';
@@ -17,7 +20,6 @@ function App(): JSX.Element {
   const threadId = '<Get thread id from chat service>';
   const displayName = '<Display Name>';
 
-  registerIcons({ icons: DEFAULT_COMPONENT_ICONS });
 
   const tokenCredential = new AzureCommunicationTokenCredential(userAccessToken);
   //Instantiate the statefulChatClient


### PR DESCRIPTION
Applications must call `initializeIcons()` (potentially in addition to `registerIcons()` to ensure that the font-based default icons are loaded correctly.

- While there, add `@fluentui/react` dependency to some quickstarts that were already using the package without installing. It used to work only because it is a transitive dependency of the UI library.