### PR TITLE
Fix microphone started error and the camera button not working

### DIFF
--- a/ui-library-starting-with-calling-stateful/README.md
+++ b/ui-library-starting-with-calling-stateful/README.md
@@ -22,7 +22,7 @@ For full instructions on how to build this code sample from scratch, look at [Qu
 ## Run the code
 
 1. Run `npm i` on the directory of the project to install dependencies
-2. Swap placeholders for identifiers in the code
+2. Swap placeholders for identifiers in `src/App.tsx`
 3. Run `npm run start`
 
 Open your browser to ` http://localhost:3000`. You should see the following:

--- a/ui-library-starting-with-calling-stateful/src/App.tsx
+++ b/ui-library-starting-with-calling-stateful/src/App.tsx
@@ -28,9 +28,16 @@ function App(): JSX.Element {
   const [call, setCall] = useState<Call>();
 
   useEffect(() => {
-    setStatefulCallClient(createStatefulCallClient({
+    const statefulCallClient = createStatefulCallClient({
       userId: { communicationUserId: userId }
-    }));
+    });
+
+    // Request camera and microphone access once we have access to the device manager
+    statefulCallClient.getDeviceManager().then(deviceManager => {
+      deviceManager.askDevicePermission({ video: true, audio: true });
+    });
+
+    setStatefulCallClient(statefulCallClient);
   }, []);
 
   useEffect(() => {
@@ -50,8 +57,8 @@ function App(): JSX.Element {
   }, [callAgent]);
 
   return (
-    <>
-      <FluentThemeProvider>
+    <FluentThemeProvider>
+      <>
         {statefulCallClient && <CallClientProvider callClient={statefulCallClient}>
           {callAgent && <CallAgentProvider callAgent={callAgent}>
             {call && <CallProvider call={call}>
@@ -59,8 +66,8 @@ function App(): JSX.Element {
             </CallProvider>}
           </CallAgentProvider>}
         </CallClientProvider>}
-      </FluentThemeProvider>
-    </>
+      </>
+    </FluentThemeProvider>
   );
 }
 

--- a/ui-library-starting-with-calling-stateful/src/CallingComponentsStateful.tsx
+++ b/ui-library-starting-with-calling-stateful/src/CallingComponentsStateful.tsx
@@ -1,4 +1,4 @@
-import { usePropsFor, VideoGallery, ControlBar, CameraButton, MicrophoneButton, ScreenShareButton, EndCallButton, useCall } from '@azure/communication-react';
+import { usePropsFor, VideoGallery, ControlBar, CameraButton, MicrophoneButton, ScreenShareButton, EndCallButton, useCall, VideoStreamOptions } from '@azure/communication-react';
 import { mergeStyles, Stack } from '@fluentui/react';
 
 function CallingComponents(): JSX.Element {
@@ -11,6 +11,10 @@ function CallingComponents(): JSX.Element {
 
   const call = useCall();
 
+  // Only enable buttons when the call has connected.
+  // For more advanced handling of pre-call configuration, see our other samples such as [Call Readiness](../../ui-library-call-readiness/README.md)
+  const buttonsDisabled = !(call?.state === 'InLobby' || call?.state === 'Connected');
+
   if (call?.state === 'Disconnected') {
     return <CallEnded />;
   }
@@ -18,18 +22,23 @@ function CallingComponents(): JSX.Element {
   return (
     <Stack className={mergeStyles({ height: '100%' })}>
       <div style={{ width: '100vw', height: '100vh' }}>
-        {videoGalleryProps && <VideoGallery {...videoGalleryProps} />}
+        {videoGalleryProps && <VideoGallery {...videoGalleryProps} localVideoViewOptions={localViewVideoOptions} />}
       </div>
 
       <ControlBar layout='floatingBottom'>
-        {cameraProps && <CameraButton  {...cameraProps} />}
-        {microphoneProps && <MicrophoneButton   {...microphoneProps} />}
-        {screenShareProps && <ScreenShareButton  {...screenShareProps} />}
-        {endCallProps && <EndCallButton {...endCallProps} />}
+        {cameraProps && <CameraButton {...cameraProps} disabled={buttonsDisabled ?? cameraProps.disabled} />}
+        {microphoneProps && <MicrophoneButton   {...microphoneProps} disabled={buttonsDisabled ?? microphoneProps.disabled} />}
+        {screenShareProps && <ScreenShareButton  {...screenShareProps} disabled={buttonsDisabled} />}
+        {endCallProps && <EndCallButton {...endCallProps} disabled={buttonsDisabled} />}
       </ControlBar>
     </Stack>
   );
 }
+
+const localViewVideoOptions: VideoStreamOptions = {
+  isMirrored: true,
+  scalingMode: 'Fit'
+};
 
 function CallEnded(): JSX.Element {
   return <h1>You ended the call.</h1>;


### PR DESCRIPTION
## What

- Disable call controls if the user is not in a call yet
  - Fixes an exception thrown by the microphone if the mic is actioned too early
- Request camera permissions
  - Fix the camera button not working
- Set local preview scale mode to Fit
  - Fixes distorted view of the local stream
- Ensure Fluent Theme provider always has a child element
  - Fixes theme provider "no children" error 

## How Tested
Ran call locally
