### PR TITLE
Update paths for the quickstarts testing scripts

### DIFF
--- a/scripts/ui-library-run-playwright-tests.mjs
+++ b/scripts/ui-library-run-playwright-tests.mjs
@@ -12,6 +12,13 @@
 
 import { exec } from "child_process";
 import { select } from "@inquirer/prompts";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const repoRoot = path.resolve(__dirname, "..");
 
 // The options for the user to choose from
 const options = [
@@ -29,6 +36,10 @@ const options = [
   },
   { value: "ui-library-quickstart-composites-with-dependency-isolation" },
 ];
+
+const quickstartFolderPath = (folder) => {
+  return path.join(repoRoot, folder);
+};
 
 // Prompt the user to choose an option
 const promptUser = async (installDependencies) => {
@@ -50,11 +61,21 @@ const promptUser = async (installDependencies) => {
 
   // The commands for each option
   const commands = {
-    "ui-library-starting-with-chat-stateful": `cd ../ui-library-starting-with-chat-stateful ${appDepsInstall} && npm run test:e2e`,
-    "ui-library-quickstart-teams-interop-meeting-chat": `cd ../ui-library-quickstart-teams-interop-meeting-chat ${appDepsInstall} && npm run test:e2e`,
-    "ui-library-filesharing-chat-composite": `cd ../ui-library-filesharing-chat-composite ${appAndAPIDepsInstall} && npm run test:e2e`,
-    "ui-library-filesharing-ui-components": `cd ../ui-library-filesharing-ui-components ${appAndAPIDepsInstall} && npm run test:e2e`,
-    "ui-library-quickstart-composites-with-dependency-isolation": `cd ../ui-library-quickstart-composites-with-dependency-isolation ${appDepsInstall} && npm run test:e2e`,
+    "ui-library-starting-with-chat-stateful": `cd ${quickstartFolderPath(
+      "ui-library-starting-with-chat-stateful"
+    )} ${appDepsInstall} && npm run test:e2e`,
+    "ui-library-quickstart-teams-interop-meeting-chat": `cd ${quickstartFolderPath(
+      "ui-library-quickstart-teams-interop-meeting-chat"
+    )} ${appDepsInstall} && npm run test:e2e`,
+    "ui-library-filesharing-chat-composite": `cd ${quickstartFolderPath(
+      "ui-library-filesharing-chat-composite"
+    )} ${appAndAPIDepsInstall} && npm run test:e2e`,
+    "ui-library-filesharing-ui-components": `cd ${quickstartFolderPath(
+      "ui-library-filesharing-ui-components"
+    )} ${appAndAPIDepsInstall} && npm run test:e2e`,
+    "ui-library-quickstart-composites-with-dependency-isolation": `cd ${quickstartFolderPath(
+      "ui-library-quickstart-composites-with-dependency-isolation"
+    )} ${appDepsInstall} && npm run test:e2e`,
   };
 
   // Run the command for the selected option

--- a/scripts/ui-library-set-variables-values.mjs
+++ b/scripts/ui-library-set-variables-values.mjs
@@ -8,26 +8,32 @@
 //        Optionally, use `--restore` to restore default values
 
 import fs from "fs";
+import path from "path";
 import readline from "readline";
+import { fileURLToPath } from "url";
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const repoRoot = path.resolve(__dirname, "..");
 // List of files to be updated
 const filesToUpdate = [
   // ui-library-filesharing-chat-composite
-  "../ui-library-filesharing-chat-composite/api/local.settings.json",
-  "../ui-library-filesharing-chat-composite/app/src/App.tsx",
+  "ui-library-filesharing-chat-composite/api/local.settings.json",
+  "ui-library-filesharing-chat-composite/app/src/App.tsx",
 
   // ui-library-starting-with-chat-stateful
-  "../ui-library-starting-with-chat-stateful/src/App.tsx",
+  "ui-library-starting-with-chat-stateful/src/App.tsx",
 
   // ui-library-filesharing-ui-components
-  "../ui-library-filesharing-ui-components/api/local.settings.json",
-  "../ui-library-filesharing-ui-components/app/src/App.tsx",
+  "ui-library-filesharing-ui-components/api/local.settings.json",
+  "ui-library-filesharing-ui-components/app/src/App.tsx",
 
   // ui-library-quickstart-teams-interop-meeting-chat
-  "../ui-library-quickstart-teams-interop-meeting-chat/src/App.tsx",
+  "ui-library-quickstart-teams-interop-meeting-chat/src/App.tsx",
 
   // ui-library-quickstart-composites-with-dependency-isolation
-  "../ui-library-quickstart-composites-with-dependency-isolation/src/App.tsx",
+  "ui-library-quickstart-composites-with-dependency-isolation/src/App.tsx",
 
   // Add more file paths as needed
 ];
@@ -109,9 +115,11 @@ const defaultValues = {
 
 function updateFiles(files, replacements) {
   files.forEach((filePath) => {
-    fs.readFile(filePath, "utf8", (err, data) => {
+    // Path to the file from the root of the repository
+    const fullFilePath = path.join(repoRoot, filePath);
+    fs.readFile(fullFilePath, "utf8", (err, data) => {
       if (err) {
-        console.error(`Error reading file ${filePath}:`, err);
+        console.error(`Error reading file ${fullFilePath}:`, err);
         return;
       }
       // delete the next line after the update if it's multiLine string
@@ -142,11 +150,11 @@ function updateFiles(files, replacements) {
         .filter((line) => line !== "[TO BE REMOVED]")
         .join("\n");
 
-      fs.writeFile(filePath, updatedContent, "utf8", (err) => {
+      fs.writeFile(fullFilePath, updatedContent, "utf8", (err) => {
         if (err) {
-          console.error(`Error writing file ${filePath}:`, err);
+          console.error(`Error writing file ${fullFilePath}:`, err);
         } else {
-          console.log(`File ${filePath} updated successfully.`);
+          console.log(`File ${fullFilePath} updated successfully.`);
         }
       });
     });


### PR DESCRIPTION
Make path for quickstarts apps independent from the current folder for the quickstarts testing scripts

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->