### PR TITLE
Fix typo in index.html reference in webpack config

### DIFF
--- a/add-1-on-1-video-calling/webpack.config.js
+++ b/add-1-on-1-video-calling/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
     plugins: [
         new CopyPlugin({
             patterns: [
-                './index.thml',
+                './index.html',
                 './styles.css'
             ]
         }),


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* * Fixes a typo in the `webpack.config.js` file where `index.thml` was incorrectly referenced instead of `index.html`. This resolves the error that prevents the development server from correctly locating the HTML template.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/JovanGH/communication-services-javascript-quickstarts.git
cd communication-services-javascript-quickstarts
git checkout fix-typo-index-html
cd add-1-on-1-video-calling
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
npx webpack serve --config webpack.config.js
```

## What to Check
Verify that the following are valid
* Verify that the following are valid:  
* The development server starts without error.  
* The correct `index.html` file is used and the app loads in the browser at `http://localhost:8080`.


## Other Information
<!-- Add any other helpful information that may be needed here. -->
N/A